### PR TITLE
Migrate renderer to WebGPU and overhaul scene visuals

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
         "@react-spring/core": "^10.1.1",
         "@react-three/drei": "11.0.0-alpha.5",
         "@react-three/fiber": "10.0.0-alpha.2",
-        "@react-three/postprocessing": "^3.0.4",
         "@types/node": "25.9.3",
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@react-three/fiber':
         specifier: 10.0.0-alpha.2
         version: 10.0.0-alpha.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.184.0)
-      '@react-three/postprocessing':
-        specifier: ^3.0.4
-        version: 3.0.4(@react-three/fiber@10.0.0-alpha.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.184.0))(@types/three@0.184.1)(react@19.2.7)(three@0.184.0)
       '@types/node':
         specifier: 25.9.3
         version: 25.9.3
@@ -505,13 +502,6 @@ packages:
     peerDependenciesMeta:
       react-dom:
         optional: true
-
-  '@react-three/postprocessing@3.0.4':
-    resolution: {integrity: sha512-e4+F5xtudDYvhxx3y0NtWXpZbwvQ0x1zdOXWTbXMK6fFLVDd4qucN90YaaStanZGS4Bd5siQm0lGL/5ogf8iDQ==}
-    peerDependencies:
-      '@react-three/fiber': ^9.0.0
-      react: ^19.0
-      three: '>= 0.156.0'
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -1505,12 +1495,6 @@ packages:
       '@types/three': '>=0.134.0'
       three: '>=0.134.0'
 
-  maath@0.6.0:
-    resolution: {integrity: sha512-dSb2xQuP7vDnaYqfoKzlApeRcR2xtN8/f7WV/TMAkBC8552TwTLtOO0JTcSygkYMjNDPoo6V01jTw/aPi4JrMw==}
-    peerDependencies:
-      '@types/three': '>=0.144.0'
-      three: '>=0.144.0'
-
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -1538,12 +1522,6 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  n8ao@1.10.1:
-    resolution: {integrity: sha512-hhI1pC+BfOZBV1KMwynBrVlIm8wqLxj/abAWhF2nZ0qQKyzTSQa1QtLVS2veRiuoBQXojxobcnp0oe+PUoxf/w==}
-    peerDependencies:
-      postprocessing: '>=6.30.0'
-      three: '>=0.137'
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -1668,11 +1646,6 @@ packages:
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
-
-  postprocessing@6.39.1:
-    resolution: {integrity: sha512-R2dG2zy+BAx3USl5EHw+PvnrlbT5PKnZVp3se0HCR0pWH8WQdh742yNG4YWOsq6c0bFpffk0Gd2RqPeoP/wKng==}
-    peerDependencies:
-      three: '>= 0.168.0 < 0.185.0'
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -2507,17 +2480,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - immer
-
-  '@react-three/postprocessing@3.0.4(@react-three/fiber@10.0.0-alpha.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.184.0))(@types/three@0.184.1)(react@19.2.7)(three@0.184.0)':
-    dependencies:
-      '@react-three/fiber': 10.0.0-alpha.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.184.0)
-      maath: 0.6.0(@types/three@0.184.1)(three@0.184.0)
-      n8ao: 1.10.1(postprocessing@6.39.1(three@0.184.0))(three@0.184.0)
-      postprocessing: 6.39.1(three@0.184.0)
-      react: 19.2.7
-      three: 0.184.0
-    transitivePeerDependencies:
-      - '@types/three'
 
   '@rtsao/scc@1.1.0': {}
 
@@ -3659,11 +3621,6 @@ snapshots:
       '@types/three': 0.184.1
       three: 0.184.0
 
-  maath@0.6.0(@types/three@0.184.1)(three@0.184.0):
-    dependencies:
-      '@types/three': 0.184.1
-      three: 0.184.0
-
   math-intrinsics@1.1.0: {}
 
   merge2@1.4.1: {}
@@ -3686,11 +3643,6 @@ snapshots:
   minimist@1.2.8: {}
 
   ms@2.1.3: {}
-
-  n8ao@1.10.1(postprocessing@6.39.1(three@0.184.0))(three@0.184.0):
-    dependencies:
-      postprocessing: 6.39.1(three@0.184.0)
-      three: 0.184.0
 
   nanoid@3.3.12: {}
 
@@ -3819,10 +3771,6 @@ snapshots:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
-
-  postprocessing@6.39.1(three@0.184.0):
-    dependencies:
-      three: 0.184.0
 
   prelude-ls@1.2.1: {}
 

--- a/src/lib/AdminControls.tsx
+++ b/src/lib/AdminControls.tsx
@@ -1,31 +1,116 @@
 import { CameraControls } from "@react-three/drei";
 import FlatText from "./FlatText";
 import { useFrame, useThree } from "@react-three/fiber";
-import { useRef } from "react";
+import { useEffect, useRef, type ComponentRef } from "react";
 import { Vector3 } from "three";
+import { LOOK_TARGET } from "./FlyCameraController";
+
+type CameraControlsImpl = ComponentRef<typeof CameraControls>;
 
 interface Props {
   enabled: boolean;
 }
 
+// Distance the camera moves per second while an arrow key is held.
+const ROAM_SPEED = 120;
+
+// How far in front of the camera the "slyfox" text floats.
+const TEXT_DISTANCE = 60;
+
 export default function AdminControls({ enabled }: Props) {
   const groupRef = useRef<any>(null!);
+  const controls = useRef<CameraControlsImpl>(null!);
   const { camera } = useThree();
+  const roam = useRef({ up: false, down: false, left: false, right: false });
+  const forward = useRef(new Vector3());
+  // Camera position captured at the moment admin is enabled, plus a countdown of
+  // frames over which to (re-)seat CameraControls into it. CameraControls resets
+  // its target to the origin on mount and may not be connected on the exact first
+  // frame, so we re-apply the seat for a few frames until it sticks.
+  const seatPos = useRef(new Vector3());
+  const seatFrames = useRef(0);
 
-  useFrame(() => {
+  // On enabling admin, capture the camera's current position to seat the controls
+  // into, looking at the tornado center (so the view never snaps/looks away).
+  useEffect(() => {
+    if (!enabled) return;
+    camera.updateMatrixWorld();
+    seatPos.current.copy(camera.position);
+    seatFrames.current = 5;
+  }, [enabled, camera]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const set = (code: string, pressed: boolean): boolean => {
+      switch (code) {
+        case "ArrowUp":
+        case "KeyW":
+          roam.current.up = pressed;
+          return true;
+        case "ArrowDown":
+        case "KeyS":
+          roam.current.down = pressed;
+          return true;
+        case "ArrowLeft":
+        case "KeyA":
+          roam.current.left = pressed;
+          return true;
+        case "ArrowRight":
+        case "KeyD":
+          roam.current.right = pressed;
+          return true;
+        default:
+          return false;
+      }
+    };
+    const onDown = (e: KeyboardEvent) => {
+      if (set(e.code, true)) e.preventDefault();
+    };
+    const onUp = (e: KeyboardEvent) => set(e.code, false);
+    window.addEventListener("keydown", onDown);
+    window.addEventListener("keyup", onUp);
+    return () => {
+      roam.current = { up: false, down: false, left: false, right: false };
+      window.removeEventListener("keydown", onDown);
+      window.removeEventListener("keyup", onUp);
+    };
+  }, [enabled]);
+
+  useFrame((_, delta) => {
+    if (controls.current) {
+      // Re-seat the controls at the captured position, looking at the tornado
+      // center, for a few frames after enabling — so it keeps the view instead of
+      // snapping to CameraControls' default origin target.
+      if (seatFrames.current > 0) {
+        controls.current.setLookAt(
+          seatPos.current.x,
+          seatPos.current.y,
+          seatPos.current.z,
+          LOOK_TARGET.x,
+          LOOK_TARGET.y,
+          LOOK_TARGET.z,
+          false,
+        );
+        seatFrames.current -= 1;
+      }
+
+      const step = ROAM_SPEED * delta;
+      const r = roam.current;
+      // Arrows fly along the current view (forward) and strafe (truck).
+      if (r.up) controls.current.forward(step, false);
+      if (r.down) controls.current.forward(-step, false);
+      if (r.right) controls.current.truck(step, 0, false);
+      if (r.left) controls.current.truck(-step, 0, false);
+    }
+
     if (!enabled || !groupRef.current) return;
-
-    const textPositionOffset = new Vector3(0, 0, 60);
-    const cameraDirection = new Vector3();
-    camera.getWorldDirection(cameraDirection);
-    const textPosition = new Vector3();
-    textPosition
+    // World-space: float the text TEXT_DISTANCE ahead of the camera and match its
+    // orientation so it stays readable (FlatText faces +z, same as the camera).
+    camera.getWorldDirection(forward.current);
+    groupRef.current.position
       .copy(camera.position)
-      .add(cameraDirection.multiplyScalar(textPositionOffset.z));
-    textPosition.y += textPositionOffset.y;
-
-    groupRef.current.position.copy(textPosition);
-    groupRef.current.lookAt(camera.position);
+      .addScaledVector(forward.current, TEXT_DISTANCE);
+    groupRef.current.quaternion.copy(camera.quaternion);
   });
 
   return enabled ? (
@@ -42,7 +127,7 @@ export default function AdminControls({ enabled }: Props) {
           />
         </FlatText>
       </group>
-      <CameraControls minDistance={0} maxDistance={500} />
+      <CameraControls ref={controls} minDistance={0} maxDistance={Infinity} />
     </>
   ) : null;
 }

--- a/src/lib/DynamicScene.tsx
+++ b/src/lib/DynamicScene.tsx
@@ -1,9 +1,18 @@
 import { PerspectiveCamera } from "@react-three/drei";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Particles } from "./Particles";
-import { PerspectiveCamera as THREEPerspectiveCamera, FogExp2 } from "three";
-import { useFrame } from "@react-three/fiber";
-import { map } from "./util/util";
+import {
+  PerspectiveCamera as THREEPerspectiveCamera,
+  FogExp2,
+  ACESFilmicToneMapping,
+  NoToneMapping,
+} from "three/webgpu";
+import { useFrame, useThree } from "@react-three/fiber";
+import {
+  FlyCameraController,
+  createInput,
+  type FlyInput,
+} from "./FlyCameraController";
 import AdminControls from "./AdminControls";
 import FadingTextColumnGroup from "./FadingTextColumnGroup";
 import SceneEffects from "./SceneEffects";
@@ -12,71 +21,135 @@ import { sceneConfig, SCENE_BG_COLOR } from "./sceneConfig";
 
 interface Props {
   adminEnabled: boolean;
+  onReady?: () => void;
 }
 
-const fog = sceneConfig.fog ? new FogExp2(SCENE_BG_COLOR, 0.0025) : null;
+// Exponential fog fades distant content to the dark background, giving the
+// "deep space" backdrop behind the gradient sky. Density controls how quickly it
+// falls off — higher = thicker/closer, but a longer dark ramp that's more prone
+// to banding (mitigated by the output dither in SceneEffects).
+const FOG_DENSITY = 0.002;
 
-export default function DynamicScene({ adminEnabled }: Props) {
+// How far in front of the camera the link column floats as it follows along.
+const TEXT_FOLLOW_DISTANCE = 200;
+
+// Keys that drive each flight direction (WASD + arrows).
+const KEY_BINDINGS: Record<string, keyof FlyInput> = {
+  KeyW: "forward",
+  ArrowUp: "forward",
+  KeyS: "back",
+  ArrowDown: "back",
+  KeyA: "left",
+  ArrowLeft: "left",
+  KeyD: "right",
+  ArrowRight: "right",
+};
+
+export default function DynamicScene({ adminEnabled, onReady }: Props) {
   const cam = useRef<THREEPerspectiveCamera>(null!);
-  const [offset] = useState(() => 1_000 * Math.random());
+  const get = useThree((s) => s.get);
   const sceneReady = useRef(false);
+  const [controller] = useState(
+    () => new FlyCameraController(1_000 * Math.random()),
+  );
+  const input = useRef<FlyInput>(createInput());
+  // Forward-flight progress in [0, 1], shared with the link column so it shrinks
+  // as the camera moves forward and grows moving back.
+  const forwardProgress = useRef(0);
 
-  useFrame((state) => {
+  // Apply fog + tone mapping from the current config. Read here (not at module
+  // scope / renderer-creation time) so a config toggle that remounts this
+  // component re-evaluates them.
+  useEffect(() => {
+    const { scene, renderer } = get();
+    scene.fog = sceneConfig.fog
+      ? new FogExp2(SCENE_BG_COLOR, FOG_DENSITY)
+      : null;
+    scene.background = null;
+    if (renderer) {
+      renderer.toneMapping = sceneConfig.toneMapping
+        ? ACESFilmicToneMapping
+        : NoToneMapping;
+    }
+    return () => {
+      get().scene.fog = null;
+    };
+  }, [get]);
+
+  useEffect(() => {
+    // In admin mode AdminControls owns the keyboard; don't also drive fly input.
+    if (adminEnabled) return;
+    const setKey = (code: string, pressed: boolean) => {
+      const dir = KEY_BINDINGS[code];
+      if (!dir) return;
+      input.current[dir] = pressed;
+      if (pressed) controller.beginManual();
+    };
+    const onKeyDown = (e: KeyboardEvent) => setKey(e.code, true);
+    const onKeyUp = (e: KeyboardEvent) => setKey(e.code, false);
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keyup", onKeyUp);
+    return () => {
+      input.current = createInput();
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keyup", onKeyUp);
+    };
+  }, [controller, adminEnabled]);
+
+  useFrame((state, delta) => {
     if (!sceneReady.current) {
-      state.scene.fog = fog;
-      state.scene.background = null;
       sceneReady.current = true;
+      onReady?.();
     }
 
     if (adminEnabled) return;
 
-    const t = state.elapsed + offset;
-    const timeScalingConstant = 10;
-    const time = t / timeScalingConstant;
-    const radius = map(Math.sin(time) + Math.cos(time), -1.5, 1.5, -5, 5);
-    const x = radius * Math.cos(time);
-    const y = radius * Math.sin(time);
-    cam.current.lookAt(0, 0, -390);
-    cam.current.position.set(x, y, radius - 23);
+    controller.update(cam.current, state.elapsed, delta, input.current);
+    forwardProgress.current = controller.forwardProgress;
   });
 
   return (
     <>
-      <PerspectiveCamera
-        ref={cam}
-        position={[0, 0, 0]}
-        fov={70}
-        near={10}
-        far={1000}
-      >
-        <AdminControls enabled={adminEnabled} />
-        <ambientLight intensity={sceneConfig.directionalLight ? 1 : 3} />
-        {sceneConfig.directionalLight && (
-          <directionalLight
-            position={[50, 50, 0]}
-            intensity={2}
-            castShadow
-            shadow-mapSize-width={1024}
-            shadow-mapSize-height={1024}
-            shadow-camera-far={500}
-          />
-        )}
-        <Particles emissive={sceneConfig.emissiveStars} />
-        <FadingTextColumnGroup
-          textArray={[
-            { displayText: "résumé", url: "./resume.pdf" },
-            {
-              displayText: "github",
-              url: "https://github.com/ohslyfox",
-            },
-            {
-              displayText: "linkedin",
-              url: "https://www.linkedin.com/in/patrick-f-50ab75132",
-            },
-          ]}
-          position={{ x: 0, y: 0, z: -60 }}
+      {/* No `position` prop: r3f re-applies element props on every render, so a
+          static position would snap the camera back to it whenever this component
+          re-renders (e.g. when admin mode toggles). The controllers drive the
+          camera position every frame instead. */}
+      <PerspectiveCamera ref={cam} makeDefault fov={70} near={1} far={1000} />
+      <AdminControls enabled={adminEnabled} />
+
+      {/* The link column follows the camera in world space (so it stays in
+          view) but counter-scales with forward progress: shrinks flying in,
+          grows flying back. */}
+      <FadingTextColumnGroup
+        cameraRef={cam}
+        progressRef={forwardProgress}
+        followDistance={TEXT_FOLLOW_DISTANCE}
+        follow={!adminEnabled}
+        textArray={[
+          { displayText: "résumé", url: "./resume.pdf" },
+          {
+            displayText: "github",
+            url: "https://github.com/ohslyfox",
+          },
+          {
+            displayText: "linkedin",
+            url: "https://www.linkedin.com/in/patrick-f-50ab75132",
+          },
+        ]}
+        position={{ x: 0, y: 0, z: 0 }}
+      />
+      <ambientLight intensity={0.06} />
+      {sceneConfig.directionalLight && (
+        <directionalLight
+          position={[50, 50, 200]}
+          intensity={1.2}
+          castShadow
+          shadow-mapSize-width={1024}
+          shadow-mapSize-height={1024}
+          shadow-camera-far={500}
         />
-      </PerspectiveCamera>
+      )}
+      <Particles emissive={sceneConfig.emissiveStars} />
       {sceneConfig.sceneBackground && <Starfield />}
       <SceneEffects />
     </>

--- a/src/lib/FadingTextColumnGroup.tsx
+++ b/src/lib/FadingTextColumnGroup.tsx
@@ -1,6 +1,14 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
 import { useFrame } from "@react-three/fiber";
 import { useSpring } from "@react-spring/core";
+import { Camera, Group, Vector3 } from "three";
 import FlatClickText from "./FlatClickText";
 
 interface TextProps {
@@ -15,13 +23,45 @@ interface Props {
     readonly y: number;
     readonly z: number;
   };
+  // The camera the column follows, and forward-flight progress in [0, 1].
+  readonly cameraRef: RefObject<Camera | null>;
+  readonly progressRef: RefObject<number>;
+  // Distance in front of the camera the column floats.
+  readonly followDistance: number;
+  // When false (admin free-roam), the column rests at a fixed default position
+  // instead of tracking the camera.
+  readonly follow: boolean;
 }
+
+// Column scale at the back (progress 0, full) and deep forward (progress 1).
+const SCALE_BACK = 1;
+const SCALE_FORWARD = 0.45;
 
 export default function FadingTextColumnGroup(props: Props) {
   const [opacity, setOpacity] = useState(1);
   const [movementTime, setMovementTime] = useState(0);
   const [show, setShow] = useState(true);
   const tRef = useRef(0);
+  // Mirrors `opacity` so the per-frame loop can skip setState when it hasn't moved.
+  const opacityRef = useRef(1);
+  const groupRef = useRef<Group>(null!);
+  const forward = useRef(new Vector3());
+  // The column is the single owner of the page cursor: links report hover here
+  // (hoverCount > 0 → pointer) and the fade state hides it (faded → none). We
+  // remember the last applied value so the per-frame derivation only writes on a
+  // change.
+  const hoverCount = useRef(0);
+  const cursorRef = useRef<string>("auto");
+
+  const setCursor = useCallback((cursor: string) => {
+    if (cursorRef.current === cursor) return;
+    cursorRef.current = cursor;
+    document.body.style.cursor = cursor;
+  }, []);
+
+  const onHoverChange = useCallback((hovered: boolean) => {
+    hoverCount.current = Math.max(0, hoverCount.current + (hovered ? 1 : -1));
+  }, []);
 
   const { scale } = useSpring({
     scale: show ? 1 : 0,
@@ -45,7 +85,41 @@ export default function FadingTextColumnGroup(props: Props) {
       setShow(true);
     }
 
-    setOpacity(scale.get());
+    // Only push opacity into React state when it actually moves: scale.get() is
+    // constant while the spring is settled, so re-rendering the whole text column
+    // every frame (opacity feeds the FlatClickText props) would be wasted work.
+    const currentOpacity = scale.get();
+    if (Math.abs(currentOpacity - opacityRef.current) > 0.001) {
+      opacityRef.current = currentOpacity;
+      setOpacity(currentOpacity);
+    }
+
+    // Derive the cursor: hidden when the text is fully faded (nothing to click),
+    // pointer while a link is hovered, otherwise the default.
+    const hidden = currentOpacity <= 0.001;
+    setCursor(hidden ? "none" : hoverCount.current > 0 ? "pointer" : "auto");
+
+    const group = groupRef.current;
+    const camera = props.cameraRef.current;
+    if (!props.follow || !camera) {
+      // Admin free-roam: rest at a fixed default spot ahead of the origin.
+      group.position.set(0, 0, -props.followDistance);
+      group.quaternion.identity();
+      group.scale.setScalar(SCALE_BACK);
+      return;
+    }
+
+    // Follow the camera: sit `followDistance` ahead of it and match its
+    // orientation (so the text faces the viewer exactly as a camera child would).
+    camera.getWorldDirection(forward.current);
+    group.position
+      .copy(camera.position)
+      .addScaledVector(forward.current, props.followDistance);
+    group.quaternion.copy(camera.quaternion);
+
+    // Counter-scale with forward progress: shrink flying in, grow flying back.
+    const p = props.progressRef.current ?? 0;
+    group.scale.setScalar(SCALE_BACK + (SCALE_FORWARD - SCALE_BACK) * p);
   });
 
   useEffect(() => {
@@ -55,11 +129,13 @@ export default function FadingTextColumnGroup(props: Props) {
     window.addEventListener("mousemove", handleMouseMove);
     return () => {
       window.removeEventListener("mousemove", handleMouseMove);
+      // Don't leave the cursor hidden/pointer if we unmount mid-fade or mid-hover.
+      document.body.style.cursor = "auto";
     };
   }, []);
 
-  const textDistance = 12.5; // Distance between each line of text
-  const columnOffset = (textDistance * (props.textArray.length - 1)) / 2; // Offset to center the column vertically
+  const textDistance = 32;
+  const columnOffset = (textDistance * (props.textArray.length - 1)) / 2;
 
   const textElements = useMemo(() => {
     return props.textArray.map((text, index) => {
@@ -69,12 +145,13 @@ export default function FadingTextColumnGroup(props: Props) {
           displayText={text.displayText}
           url={text.url}
           opacity={opacity}
+          onHoverChange={onHoverChange}
           position={{
             x: props.position.x,
             y: props.position.y - textDistance * index + columnOffset,
             z: props.position.z,
           }}
-          size={{ default: 8, hovered: 10 }}
+          size={{ default: 20, hovered: 24 }}
           color={{
             default: "#4cc1ff",
             hovered: "#ffc04c",
@@ -82,7 +159,7 @@ export default function FadingTextColumnGroup(props: Props) {
         />
       );
     });
-  }, [props.textArray, props.position, opacity, columnOffset]);
+  }, [props.textArray, props.position, opacity, columnOffset, onHoverChange]);
 
-  return <>{textElements}</>;
+  return <group ref={groupRef}>{textElements}</group>;
 }

--- a/src/lib/FlatClickText.tsx
+++ b/src/lib/FlatClickText.tsx
@@ -21,11 +21,16 @@ export interface FlatClickTextOps {
   };
   readonly opacity?: number;
   readonly url?: string;
+  // Reports hover enter/leave so the owner can decide the page cursor (it also
+  // needs to hide the cursor entirely when the text is faded out). When omitted,
+  // this text manages the cursor itself.
+  readonly onHoverChange?: (hovered: boolean) => void;
 }
 
 export default function FlatClickText(opts: FlatClickTextOps) {
   const [isHovered, setIsHovered] = useState(false);
   const groupRef = useRef<Group>(null!);
+  const { onHoverChange } = opts;
 
   const { scale } = useSpring({
     scale: isHovered ? opts.size.hovered : opts.size.default,
@@ -42,13 +47,15 @@ export default function FlatClickText(opts: FlatClickTextOps) {
 
   const onPointerOver = useCallback(() => {
     setIsHovered(true);
-    document.body.style.cursor = "pointer";
-  }, []);
+    if (onHoverChange) onHoverChange(true);
+    else document.body.style.cursor = "pointer";
+  }, [onHoverChange]);
 
   const onPointerOut = useCallback(() => {
     setIsHovered(false);
-    document.body.style.cursor = "auto";
-  }, []);
+    if (onHoverChange) onHoverChange(false);
+    else document.body.style.cursor = "auto";
+  }, [onHoverChange]);
 
   const onClick = useCallback(
     (e: any) => {
@@ -82,7 +89,10 @@ export default function FlatClickText(opts: FlatClickTextOps) {
           <meshStandardMaterial
             color={isHovered ? opts.color.hovered : opts.color.default}
             emissive={isHovered ? opts.color.hovered : opts.color.default}
-            emissiveIntensity={0.6}
+            // Fade the emissive with opacity so the bloom glow fades out together
+            // with the text — otherwise the (opacity-independent) bloom halo lingers
+            // and the text appears to blur away instead of fading.
+            emissiveIntensity={0.6 * (opts.opacity ?? 1)}
             opacity={opts.opacity}
             transparent={true}
             depthTest={true}

--- a/src/lib/FlyCameraController.ts
+++ b/src/lib/FlyCameraController.ts
@@ -1,0 +1,244 @@
+import { Vector3 } from "three/webgpu";
+import { map } from "./util/util";
+import { tornado } from "./Particles";
+
+// Point every camera mode keeps in frame (matches the original auto-cam).
+export const LOOK_TARGET = new Vector3(0, 0, -390);
+const WORLD_UP = new Vector3(0, 1, 0);
+
+// Manual-flight physics.
+const ACCELERATION = 140; // units/s² applied per held axis
+const MAX_SPEED = 60; // units/s clamp on velocity
+const DRAG = 1.6; // air resistance: velocity *= exp(-DRAG * dt); lower = coasts longer
+// Keep the camera this fraction inside the cone wall so stars don't clip past it.
+const BOUNDS_FRACTION = 0.8;
+// Minimum usable radius near the cone tip so the camera always has room to move.
+const MIN_BOUND_RADIUS = 6;
+// Distance from a boundary over which velocity heading into it is eased to zero,
+// so the camera glides to a smooth stop at the edge instead of snapping.
+const BOUNDARY_CUSHION = 30;
+
+// Idle handling.
+const IDLE_TIMEOUT = 10; // seconds of no input before returning to auto
+const RETURN_DURATION = 1.5; // seconds to glide back onto the auto path
+
+type Mode = "auto" | "manual" | "returning";
+
+export interface FlyInput {
+  forward: boolean;
+  back: boolean;
+  left: boolean;
+  right: boolean;
+}
+
+export function createInput(): FlyInput {
+  return { forward: false, back: false, left: false, right: false };
+}
+
+/**
+ * Drives the scene camera. By default it follows the gentle auto-orbit; when
+ * WASD/arrow input arrives it switches to physics-based free flight (camera-
+ * relative, with acceleration, drag, and bounds that keep it inside the particle
+ * tornado), always facing the tornado center. After {@link IDLE_TIMEOUT} seconds
+ * idle it glides back onto the auto path and resumes.
+ */
+export class FlyCameraController {
+  private mode: Mode = "auto";
+  private idleTime = 0;
+  private returnTime = 0;
+
+  private readonly position = new Vector3();
+  private readonly velocity = new Vector3();
+
+  // Reused scratch vectors so update() never allocates.
+  private readonly forward = new Vector3();
+  private readonly right = new Vector3();
+  private readonly accel = new Vector3();
+  private readonly autoPos = new Vector3();
+  private readonly returnFrom = new Vector3();
+
+  // Random phase so multiple loads don't share the same orbit timing.
+  constructor(private readonly autoOffset: number) {}
+
+  /** Current camera world position (read-only; do not mutate). */
+  get cameraPosition(): Vector3 {
+    return this.position;
+  }
+
+  /**
+   * How far forward into the tornado the camera has flown, in [0, 1]: 0 at the
+   * near/back limit, 1 deep in. Drives the link column's counter-scaling.
+   */
+  get forwardProgress(): number {
+    const { flightZNear, flightZFar } = tornado;
+    const t = (this.position.z - flightZNear) / (flightZFar - flightZNear);
+    return Math.max(0, Math.min(1, t));
+  }
+
+  /** Called on any key press to take manual control. */
+  beginManual(): void {
+    if (this.mode === "auto" || this.mode === "returning") {
+      this.mode = "manual";
+    }
+    this.idleTime = 0;
+  }
+
+  /**
+   * Advances the camera one frame and writes its transform.
+   * @param camera object with position + lookAt (the drei PerspectiveCamera)
+   * @param elapsed total scene time (for the auto orbit)
+   * @param dt frame delta in seconds
+   * @param input current key state
+   */
+  update(
+    camera: { position: Vector3; lookAt: (v: Vector3) => void },
+    elapsed: number,
+    dt: number,
+    input: FlyInput,
+  ): void {
+    this.computeAutoPosition(elapsed, this.autoPos);
+
+    switch (this.mode) {
+      case "auto":
+        this.position.copy(this.autoPos);
+        break;
+      case "manual":
+        this.stepManual(dt, input);
+        break;
+      case "returning":
+        this.stepReturn(dt);
+        break;
+    }
+
+    camera.position.copy(this.position);
+    camera.lookAt(LOOK_TARGET);
+  }
+
+  // The original gentle Lissajous orbit near the tornado mouth.
+  private computeAutoPosition(elapsed: number, target: Vector3): void {
+    const time = (elapsed + this.autoOffset) / 10;
+    const radius = map(Math.sin(time) + Math.cos(time), -1.5, 1.5, -5, 5);
+    target.set(radius * Math.cos(time), radius * Math.sin(time), radius - 23);
+  }
+
+  private stepManual(dt: number, input: FlyInput): void {
+    // The camera looks at the target, so "forward" is toward it and "right" is
+    // the horizontal perpendicular (cross with world up). Derived each frame from
+    // the current position.
+    this.forward.copy(LOOK_TARGET).sub(this.position).normalize();
+    this.right.crossVectors(this.forward, WORLD_UP).normalize();
+
+    this.accel.set(0, 0, 0);
+    if (input.forward) this.accel.addScaledVector(this.forward, 1);
+    if (input.back) this.accel.addScaledVector(this.forward, -1);
+    if (input.right) this.accel.addScaledVector(this.right, 1);
+    if (input.left) this.accel.addScaledVector(this.right, -1);
+    if (this.accel.lengthSq() > 0) {
+      this.accel.normalize().multiplyScalar(ACCELERATION);
+    }
+
+    // Integrate velocity with acceleration, then apply drag and clamp speed.
+    this.velocity.addScaledVector(this.accel, dt);
+    this.velocity.multiplyScalar(Math.exp(-DRAG * dt));
+    if (this.velocity.lengthSq() > MAX_SPEED * MAX_SPEED) {
+      this.velocity.setLength(MAX_SPEED);
+    }
+
+    // Ease velocity heading into the z-limits so the camera decelerates into the
+    // edge instead of overshooting and snapping back at the clamp.
+    this.cushionZ();
+
+    this.position.addScaledVector(this.velocity, dt);
+    // Only redirect momentum along the wall while a strafe key is held; otherwise
+    // the camera just stops at the wall and any residual orbit decays via drag.
+    const strafing = input.left || input.right;
+    this.applyBounds(strafing);
+
+    // Idle bookkeeping: any held key keeps us manual; otherwise count toward auto.
+    const active = input.forward || input.back || input.left || input.right;
+    this.idleTime = active ? 0 : this.idleTime + dt;
+    if (this.idleTime >= IDLE_TIMEOUT) {
+      this.mode = "returning";
+      this.returnTime = 0;
+      this.returnFrom.copy(this.position);
+    }
+  }
+
+  // Glide from where flight left off back onto the live auto-orbit position.
+  private stepReturn(dt: number): void {
+    this.returnTime += dt;
+    const t = Math.min(1, this.returnTime / RETURN_DURATION);
+    const eased = t * t * (3 - 2 * t); // smoothstep
+    this.position.lerpVectors(this.returnFrom, this.autoPos, eased);
+    if (t >= 1) {
+      this.mode = "auto";
+      this.velocity.set(0, 0, 0);
+    }
+  }
+
+  // Eases the z-velocity to zero as the camera nears a z-limit, so it glides to
+  // a stop at the edge. Only damps velocity heading *toward* the boundary, so you
+  // can always accelerate back away from it.
+  private cushionZ(): void {
+    const { flightZNear, flightZFar } = tornado;
+    if (this.velocity.z > 0) {
+      const room = flightZNear - this.position.z; // distance to the near limit
+      if (room < BOUNDARY_CUSHION) {
+        this.velocity.z *= Math.max(0, room / BOUNDARY_CUSHION);
+      }
+    } else if (this.velocity.z < 0) {
+      const room = this.position.z - flightZFar; // distance to the far limit
+      if (room < BOUNDARY_CUSHION) {
+        this.velocity.z *= Math.max(0, room / BOUNDARY_CUSHION);
+      }
+    }
+  }
+
+  // Clamp z to the flight range and the xy-radius to the cone at that depth, so
+  // the camera stays inside the tornado. While `strafing`, the outward velocity
+  // at the radial wall is redirected into a slide along the wall (tangent of the
+  // boundary circle) so the strafe carries you around the edge; otherwise the
+  // outward velocity is just cancelled, so the camera stops and any residual
+  // orbit decays via drag rather than spinning forever.
+  private applyBounds(strafing: boolean): void {
+    if (this.position.z > tornado.flightZNear) {
+      this.position.z = tornado.flightZNear;
+      this.velocity.z = Math.min(0, this.velocity.z);
+    } else if (this.position.z < tornado.flightZFar) {
+      this.position.z = tornado.flightZFar;
+      this.velocity.z = Math.max(0, this.velocity.z);
+    }
+
+    const maxRadius = Math.max(
+      MIN_BOUND_RADIUS,
+      tornado.radiusAt(this.position.z) * BOUNDS_FRACTION,
+    );
+    const r = Math.hypot(this.position.x, this.position.y);
+    if (r <= maxRadius) return;
+
+    this.position.x *= maxRadius / r;
+    this.position.y *= maxRadius / r;
+
+    const nx = this.position.x / maxRadius;
+    const ny = this.position.y / maxRadius;
+    const radialSpeed = this.velocity.x * nx + this.velocity.y * ny;
+    if (radialSpeed <= 0) return;
+
+    if (strafing) {
+      // CCW tangent of the outward normal (-y, x); flip to match current motion.
+      let tx = -ny;
+      let ty = nx;
+      if (this.velocity.x * tx + this.velocity.y * ty < 0) {
+        tx = -tx;
+        ty = -ty;
+      }
+      // Move the outward radial momentum onto the tangent (slide along the wall).
+      this.velocity.x += radialSpeed * (tx - nx);
+      this.velocity.y += radialSpeed * (ty - ny);
+    } else {
+      // Not strafing: just cancel the outward component so it doesn't pile up.
+      this.velocity.x -= radialSpeed * nx;
+      this.velocity.y -= radialSpeed * ny;
+    }
+  }
+}

--- a/src/lib/LoadingSkeleton.tsx
+++ b/src/lib/LoadingSkeleton.tsx
@@ -1,0 +1,97 @@
+import {
+  useEffect,
+  useState,
+  useSyncExternalStore,
+  type CSSProperties,
+} from "react";
+import styles from "../styles/LoadingSkeleton.module.css";
+
+interface Props {
+  /** When true, the overlay fades out and unmounts. */
+  hidden: boolean;
+}
+
+const STAR_COUNT = 100;
+// Must match the opacity transition in LoadingSkeleton.module.css; also the
+// fallback-timeout basis for when `transitionend` never fires.
+const FADE_OUT_MS = 600;
+const STAR_COLORS = ["#cfe8ff", "#9fd4ff", "#4cc1ff", "#7fb6c9", "#b89bc4"];
+
+interface StarStyle {
+  left: string;
+  top: string;
+  width: string;
+  height: string;
+  ["--star-color"]: string;
+  ["--twinkle-duration"]: string;
+  ["--twinkle-delay"]: string;
+}
+
+function generateStars(): StarStyle[] {
+  return Array.from({ length: STAR_COUNT }, () => {
+    const size = 1 + Math.random() * 2.5;
+    return {
+      left: `${Math.random() * 100}%`,
+      top: `${Math.random() * 100}%`,
+      width: `${size}px`,
+      height: `${size}px`,
+      "--star-color":
+        STAR_COLORS[Math.floor(Math.random() * STAR_COLORS.length)],
+      "--twinkle-duration": `${1.8 + Math.random() * 2.4}s`,
+      "--twinkle-delay": `${Math.random() * 2.5}s`,
+    };
+  });
+}
+
+// Stars are random per load but must match between the server-rendered HTML and
+// first client render (this component is in the static export). useSyncExternalStore
+// gives the server an empty list and the client the randomized one, so hydration
+// sees no stars on both sides, then React swaps in the client snapshot.
+const EMPTY_STARS: StarStyle[] = [];
+let clientStars: StarStyle[] | null = null;
+
+const subscribe = () => () => {};
+const getClientSnapshot = (): StarStyle[] => (clientStars ??= generateStars());
+const getServerSnapshot = (): StarStyle[] => EMPTY_STARS;
+
+export default function LoadingSkeleton({ hidden }: Props) {
+  const [removed, setRemoved] = useState(false);
+  const stars = useSyncExternalStore(
+    subscribe,
+    getClientSnapshot,
+    getServerSnapshot,
+  );
+
+  // Fallback unmount in case `transitionend` never fires (e.g. backgrounded tab).
+  useEffect(() => {
+    if (!hidden) return;
+    const timer = window.setTimeout(() => setRemoved(true), FADE_OUT_MS + 100);
+    return () => window.clearTimeout(timer);
+  }, [hidden]);
+
+  if (removed) return null;
+
+  return (
+    <div
+      className={`${styles.overlay} ${hidden ? styles.hidden : ""}`}
+      aria-hidden={hidden}
+      role="status"
+      aria-label="Loading scene"
+      onTransitionEnd={(e) => {
+        // Only the overlay's own opacity fade dismisses it, not bubbled child
+        // transitions.
+        if (
+          hidden &&
+          e.target === e.currentTarget &&
+          e.propertyName === "opacity"
+        ) {
+          setRemoved(true);
+        }
+      }}
+    >
+      {stars.map((style, i) => (
+        <span key={i} className={styles.star} style={style as CSSProperties} />
+      ))}
+    </div>
+  );
+}

--- a/src/lib/Particles.tsx
+++ b/src/lib/Particles.tsx
@@ -1,9 +1,11 @@
 import { Instance, Instances, useGLTF } from "@react-three/drei";
 import { useFrame } from "@react-three/fiber";
-import { useMemo, useRef } from "react";
-import { Color, MeshStandardMaterial } from "three";
+import { useEffect, useMemo, useRef } from "react";
+import { Color } from "three";
 import { ColorLerp, pastelRainbowColors } from "./util/colorLerp";
-import { TrimmedColor, map, shadeColor } from "./util/util";
+import { EmissiveStarMaterial } from "./materials/EmissiveStarMaterial";
+import { sceneConfig, type ColorLerpStyle } from "./sceneConfig";
+import { map } from "./util/util";
 
 const samplesPerRevolution = 7;
 const revolutions = 10;
@@ -12,21 +14,71 @@ const numHelixes = 4;
 const radiusScale = 0.06;
 const particlesPerHelix = samplesPerRevolution * revolutions;
 const particleCount = particlesPerHelix * numHelixes;
+const PALETTE_LENGTH = pastelRainbowColors.length;
+
+const Z_TRANSLATION = -helixLength - 10;
 
 const PI_2 = Math.PI * 2;
+
+// World-z the camera is allowed to fly between. "Forward" flies into the scene
+// depth (toward -z, deeper into the tornado body) down to FLIGHT_Z_FAR; "back"
+// pulls out toward the wide mouth, stopping at FLIGHT_Z_NEAR.
+const FLIGHT_Z_NEAR = 0;
+const FLIGHT_Z_FAR = -200;
+
+/**
+ * The particle tornado is a cone around the world z-axis: its radius grows with
+ * local helix-z (`localZ * radiusScale`) and the whole helix is shifted by
+ * {@link Z_TRANSLATION}. These describe that cone so the camera can stay inside it.
+ */
+export const tornado = {
+  /** Nearest (widest) and farthest (narrowest) world-z the helix occupies. */
+  zNear: Z_TRANSLATION + helixLength,
+  zFar: Z_TRANSLATION,
+  /** Camera flight z-range (near = shallow/wide, far = deep). */
+  flightZNear: FLIGHT_Z_NEAR,
+  flightZFar: FLIGHT_Z_FAR,
+  /** Cone radius at a given world-z (0 outside the helix's z-range). */
+  radiusAt(worldZ: number): number {
+    const localZ = worldZ - Z_TRANSLATION;
+    if (localZ <= 0 || localZ > helixLength) return 0;
+    return localZ * radiusScale;
+  },
+};
 
 interface ParticleData {
   key: string;
   x: number;
   y: number;
   z: number;
-  metadata: {
-    helix: number;
-    index: number;
-  };
+  index: number;
+  // This particle's offset (in palette segments) into the shared color loop.
+  colorOffset: number;
 }
 
+// The per-particle offset (in palette segments) into the shared color loop,
+// which determines how the rainbow is distributed:
+//  - solid:  0 for all -> every particle is the same cycling color
+//  - band:   advances along the helix -> color bands per revolution
+//  - stripe: follows the angle around the axis -> radial stripes across the width
+const colorOffsetFor = (
+  style: ColorLerpStyle,
+  t: number,
+  angle: number,
+): number => {
+  switch (style) {
+    case "solid":
+      return 0;
+    case "stripe":
+      return ((((angle % PI_2) + PI_2) % PI_2) / PI_2) * PALETTE_LENGTH;
+    case "band":
+    default:
+      return t * PALETTE_LENGTH;
+  }
+};
+
 const getStartingPoints = (): ParticleData[] => {
+  const style = sceneConfig.colorLerpStyle;
   const res: ParticleData[] = [];
   for (let h = 0; h < numHelixes; h++) {
     const helixOffset = (h / numHelixes) * PI_2;
@@ -42,37 +94,42 @@ const getStartingPoints = (): ParticleData[] => {
         x: radius * -Math.cos(angle),
         y: radius * Math.sin(angle),
         z,
-        metadata: {
-          helix: h,
-          index: p,
-        },
+        index: p,
+        colorOffset: colorOffsetFor(style, t, angle),
       });
     }
   }
   return res;
 };
 
-export const Particle = (data: ParticleData & { color: TrimmedColor }) => {
+const scratchColor = new Color();
+
+export const Particle = (data: ParticleData & { colorLerp: ColorLerp }) => {
   const ref = useRef<any>(null!);
   useFrame((state) => {
     const t = state.elapsed;
     const timeScalingConstant = 1;
     const scaleDamperConstant = 3;
     const baseScale = map(data.z, 0, helixLength, 0.005, 0.02);
-    const pulse = Math.sin(t / timeScalingConstant + data.metadata.index * 0.7);
+    const pulse = Math.sin(t / timeScalingConstant + data.index * 0.7);
     const scale = Math.max(
       0.002,
       baseScale + (pulse * baseScale) / scaleDamperConstant,
     );
 
-    const shadedColor = shadeColor(data.color, map(scale, 0, 0.1, -50, 90));
+    // Sample the shared loop at this particle's offset, then brighten/darken by
+    // size (the old shadeColor percent) as a numeric scalar — no allocations.
+    data.colorLerp.sampleInto(
+      data.colorLerp.phase + data.colorOffset,
+      scratchColor,
+    );
+    const shade = 1 + map(scale, 0, 0.1, -50, 90) / 100;
+    scratchColor.multiplyScalar(shade);
 
     ref.current.rotation.x = Math.PI / 2;
-    ref.current.rotation.y = data.metadata.index + t / 30;
+    ref.current.rotation.y = data.index + t / 30;
     ref.current.scale.setScalar(scale);
-    ref.current.color.set(
-      `rgb(${shadedColor.r},${shadedColor.g},${shadedColor.b})`,
-    );
+    ref.current.color.copy(scratchColor);
   });
   return (
     <group>
@@ -89,30 +146,20 @@ export const Particles = ({ emissive = false }: ParticlesProps) => {
   const mesh = useRef<any>(null!);
   const glf = useGLTF("./star-model.glb") as any;
 
-  const material = useMemo(() => {
-    if (!emissive) return glf.materials.Star;
-    const mat = new MeshStandardMaterial({
-      color: "#ffffff",
-      emissive: new Color("#ffffff"),
-      emissiveIntensity: 0.15,
-      roughness: 0.3,
-      metalness: 0.1,
-    });
-    mat.onBeforeCompile = (shader) => {
-      shader.fragmentShader = shader.fragmentShader.replace(
-        "#include <emissivemap_fragment>",
-        `
-                #include <emissivemap_fragment>
-                #ifdef USE_INSTANCING_COLOR
-                    totalEmissiveRadiance *= vColor;
-                #endif
-                `,
-      );
-    };
-    return mat;
-  }, [emissive, glf.materials.Star]);
+  const material = useMemo(
+    () => (emissive ? new EmissiveStarMaterial() : glf.materials.Star),
+    [emissive, glf.materials.Star],
+  );
+  // Dispose only the material we created; glf.materials.Star is owned by the GLTF.
+  useEffect(() => {
+    if (!(material instanceof EmissiveStarMaterial)) return;
+    return () => material.dispose();
+  }, [material]);
   const points = useMemo(() => getStartingPoints(), []);
-  const colorLerp = useMemo(() => new ColorLerp(pastelRainbowColors), []);
+  const colorLerp = useMemo(
+    () => new ColorLerp(pastelRainbowColors, 0.001),
+    [],
+  );
   useFrame((state) => {
     const t = state.elapsed;
     colorLerp.step();
@@ -120,12 +167,8 @@ export const Particles = ({ emissive = false }: ParticlesProps) => {
     mesh.current.rotation.z = t / 50;
   });
 
-  // the helix is drawn from 0,0,0 towards positive-z.
-  // since the camera is positioned at 0,0,0 we must translate back towards negative-z.
-  const zTranslation = -helixLength - 10;
-
   return (
-    <group ref={mesh} position={[0, 0, zTranslation]} receiveShadow>
+    <group ref={mesh} position={[0, 0, Z_TRANSLATION]} receiveShadow>
       <Instances
         limit={particleCount}
         range={particleCount}
@@ -137,9 +180,10 @@ export const Particles = ({ emissive = false }: ParticlesProps) => {
             x={p.x}
             y={p.y}
             z={p.z}
-            metadata={p.metadata}
+            index={p.index}
+            colorOffset={p.colorOffset}
             key={p.key}
-            color={colorLerp.color}
+            colorLerp={colorLerp}
           />
         ))}
       </Instances>

--- a/src/lib/SceneConfigPanel.tsx
+++ b/src/lib/SceneConfigPanel.tsx
@@ -1,0 +1,147 @@
+import { useState } from "react";
+import styles from "../styles/SceneConfigPanel.module.css";
+import {
+  sceneConfig,
+  toggleSceneOption,
+  setColorLerpStyle,
+  COLOR_LERP_STYLES,
+  type BooleanConfigKey,
+  type ColorLerpStyle,
+} from "./sceneConfig";
+
+interface Props {
+  // Called after a config value changes so the scene can pick it up.
+  onChange: () => void;
+}
+
+interface Option {
+  key: BooleanConfigKey;
+  label: string;
+  // When set, this option only applies while its parent option is enabled.
+  dependsOn?: BooleanConfigKey;
+}
+
+interface Group {
+  title: string;
+  options: Option[];
+}
+
+// Options grouped logically. `depthOfField` is omitted — deprecated/inert after
+// the WebGPU migration. Sub-options list `dependsOn` so the panel disables them
+// when their parent is off (e.g. twinkle/shooting stars need the star background).
+const GROUPS: Group[] = [
+  {
+    title: "Background",
+    options: [
+      { key: "sceneBackground", label: "Star background" },
+      {
+        key: "gradientRotation",
+        label: "Sky rotation",
+        dependsOn: "sceneBackground",
+      },
+      { key: "twinkle", label: "Twinkle", dependsOn: "sceneBackground" },
+      {
+        key: "shootingStars",
+        label: "Shooting stars",
+        dependsOn: "sceneBackground",
+      },
+    ],
+  },
+  {
+    title: "Particles & lighting",
+    options: [
+      { key: "emissiveStars", label: "Emissive stars" },
+      { key: "directionalLight", label: "Directional light" },
+    ],
+  },
+  {
+    title: "Rendering",
+    options: [
+      { key: "bloom", label: "Bloom" },
+      { key: "fog", label: "Fog" },
+      { key: "toneMapping", label: "Tone mapping" },
+    ],
+  },
+];
+
+export default function SceneConfigPanel({ onChange }: Props) {
+  const [open, setOpen] = useState(false);
+  // Local mirror so toggles re-render the panel; sceneConfig is the source.
+  const [, forceRender] = useState(0);
+
+  const toggle = (key: BooleanConfigKey) => {
+    toggleSceneOption(key);
+    forceRender((n) => n + 1);
+    onChange();
+  };
+
+  const selectColorStyle = (style: ColorLerpStyle) => {
+    setColorLerpStyle(style);
+    forceRender((n) => n + 1);
+    onChange();
+  };
+
+  return (
+    <div className={styles.root}>
+      {open && (
+        <div className={styles.panel} role="menu" aria-label="Scene options">
+          {GROUPS.map((group) => (
+            <div key={group.title} className={styles.group}>
+              <div className={styles.groupTitle}>{group.title}</div>
+              {group.options.map(({ key, label, dependsOn }) => {
+                const disabled = dependsOn ? !sceneConfig[dependsOn] : false;
+                return (
+                  <label
+                    key={key}
+                    className={`${styles.option} ${dependsOn ? styles.child : ""} ${
+                      disabled ? styles.disabled : ""
+                    }`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={sceneConfig[key]}
+                      disabled={disabled}
+                      onChange={() => toggle(key)}
+                    />
+                    <span>{label}</span>
+                  </label>
+                );
+              })}
+
+              {group.title === "Particles & lighting" && (
+                <div className={`${styles.option} ${styles.select}`}>
+                  <span>Particle color</span>
+                  <select
+                    value={sceneConfig.colorLerpStyle}
+                    onChange={(e) =>
+                      selectColorStyle(e.target.value as ColorLerpStyle)
+                    }
+                  >
+                    {COLOR_LERP_STYLES.map((style) => (
+                      <option key={style} value={style}>
+                        {style}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+      <button
+        type="button"
+        className={styles.toggle}
+        aria-label={open ? "Close scene options" : "Open scene options"}
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className={styles.bars} aria-hidden="true">
+          <span />
+          <span />
+          <span />
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/src/lib/SceneEffects.tsx
+++ b/src/lib/SceneEffects.tsx
@@ -1,48 +1,64 @@
+import { useLayoutEffect } from "react";
 import { sceneConfig } from "./sceneConfig";
-import {
-  EffectComposer,
-  Bloom,
-  DepthOfField,
-} from "@react-three/postprocessing";
+import { useThree, useStore } from "@react-three/fiber/webgpu";
+import { RenderPipeline } from "three/webgpu";
+import { pass, mrt, output, emissive } from "three/tsl";
+import { bloom } from "three/addons/tsl/display/BloomNode.js";
+import { dithered } from "./materials/dither";
 
-function BloomEffect() {
-  return (
-    <Bloom
-      luminanceThreshold={0.47}
-      luminanceSmoothing={0.9}
-      intensity={10}
-      mipmapBlur
-    />
-  );
-}
-
-function DOFEffect() {
-  return <DepthOfField target={[0, 0, 0]} bokehScale={0.33} />;
-}
+// TSL bloom, replacing the WebGL-only @react-three/postprocessing EffectComposer.
+// We build the RenderPipeline by hand instead of fiber's usePostProcessing hook,
+// which constructs the deprecated `PostProcessing` alias and warns on every load.
+// r3f's render loop calls `state.postProcessing.render()` when set, so writing
+// the pipeline to the store ourselves drives bloom without the warning.
+// DepthOfField is dropped — it has no TSL/WebGPU equivalent in three's addons.
+//
+// Bloom is fed by an emissive-only MRT buffer (not the full frame), so only the
+// glowing particles bloom — the bright sky/gradient never does, which previously
+// blew the background out to white. THRESHOLD 0 because the emissive buffer
+// already contains only what should glow. Strength is kept modest so the dense
+// convergence of particles down the tornado axis doesn't stack bloom to white.
+const BLOOM_STRENGTH = 0.5;
+const BLOOM_RADIUS = 0.4;
+const BLOOM_THRESHOLD = 0;
 
 export default function SceneEffects() {
-  if (!sceneConfig.bloom && !sceneConfig.depthOfField) return null;
+  const renderer = useThree((s) => s.renderer);
+  const scene = useThree((s) => s.scene);
+  const camera = useThree((s) => s.camera);
+  const store = useStore();
 
-  if (sceneConfig.bloom && sceneConfig.depthOfField) {
-    return (
-      <EffectComposer>
-        <BloomEffect />
-        <DOFEffect />
-      </EffectComposer>
+  useLayoutEffect(() => {
+    if (!sceneConfig.bloom || !renderer || !scene || !camera) return;
+
+    const pipeline = new RenderPipeline(renderer);
+    const scenePass = pass(scene, camera);
+    // Emissive-only MRT buffer so bloom glows just the emissive surfaces.
+    scenePass.setMRT(mrt({ output, emissive }));
+    const scenePassColor = scenePass.getTextureNode("output");
+    const emissivePass = scenePass.getTextureNode("emissive");
+    const bloomNode = bloom(
+      emissivePass,
+      BLOOM_STRENGTH,
+      BLOOM_RADIUS,
+      BLOOM_THRESHOLD,
     );
-  }
+    // Dither the final composite so the dark fog fade and gradient sky don't
+    // band on 8-bit / OLED displays.
+    pipeline.outputNode = dithered(scenePassColor.add(bloomNode));
+    store.setState({ postProcessing: pipeline });
 
-  if (sceneConfig.bloom) {
-    return (
-      <EffectComposer>
-        <BloomEffect />
-      </EffectComposer>
-    );
-  }
+    return () => {
+      // Don't clobber a newer pipeline that may have replaced ours.
+      if (store.getState().postProcessing === pipeline) {
+        store.setState({ postProcessing: null });
+      }
+      // pipeline.dispose() only frees its quad material; release the rest too.
+      pipeline.dispose();
+      bloomNode.dispose();
+      scenePass.dispose();
+    };
+  }, [renderer, scene, camera, store]);
 
-  return (
-    <EffectComposer>
-      <DOFEffect />
-    </EffectComposer>
-  );
+  return null;
 }

--- a/src/lib/ShootingStars.ts
+++ b/src/lib/ShootingStars.ts
@@ -1,0 +1,308 @@
+import {
+  BufferGeometry,
+  Float32BufferAttribute,
+  Line,
+  LineBasicMaterial,
+  Object3D,
+  Points,
+  Vector3,
+} from "three/webgpu";
+import { ShootingStarTrailMaterial } from "./materials/ShootingStarTrailMaterial";
+import { randomDirection } from "./util/sphere";
+
+const MAX_SHOOTING_STARS = 5;
+const SPAWN_CHANCE = 0.008; // per idle slot, per frame
+const TRAIL_POINTS = 24;
+
+// Stars spawn somewhere between these distances from the (camera-following) dome
+// center, so some read as nearer and some as farther.
+const SPAWN_RADIUS_MIN = 120;
+const SPAWN_RADIUS_MAX = 300;
+
+// Over its life a streak drifts radially by up to this fraction of its spawn
+// radius — half drift nearer, half farther — so the depth keeps changing.
+const DRIFT_FRACTION = 0.25;
+
+const MIN_LENGTH = 12;
+const LENGTH_RANGE = 8;
+const MIN_SPEED = 0.4;
+const SPEED_RANGE = 0.4;
+
+const TRAIL_SCATTER = 0.8;
+const HEAD_LENGTH_FRACTION = 0.3;
+
+// The streak's body is widest at its midpoint and tapers to this fraction at the
+// head and tail, giving the elliptical (lens) profile.
+const TRAIL_END_WEIGHT = 0.12;
+
+// A streak fades in over the first FADE_IN_DISTANCE of travel, fades out over
+// FADE_OUT_LENGTHS streak-lengths past its full length, and is retired after
+// DESPAWN_LENGTHS streak-lengths.
+const FADE_IN_DISTANCE = 5;
+const FADE_OUT_LENGTHS = 3;
+const DESPAWN_LENGTHS = 4;
+// While fading out a streak decelerates by up to this fraction of its speed and
+// its visible body retracts toward the head by up to this fraction of its length.
+const FADE_SLOWDOWN = 0.8;
+const FADE_RETRACTION = 0.7;
+
+const HEAD_OPACITY = 0.9;
+const TRAIL_OPACITY = 0.5;
+
+interface Streak {
+  active: boolean;
+  progress: number;
+  speed: number;
+  length: number;
+  origin: Vector3;
+  direction: Vector3;
+  radial: Vector3; // unit radial at spawn, for depth drift
+  drift: number; // signed radial drift distance applied over the streak's life
+  // Fixed per-trail-point xyz jitter, picked once at spawn so the trail keeps a
+  // stable shape instead of re-scattering (and shimmering) every frame.
+  scatter: Float32Array;
+}
+
+function createStreak(): Streak {
+  return {
+    active: false,
+    progress: 0,
+    speed: 0,
+    length: 0,
+    origin: new Vector3(),
+    direction: new Vector3(),
+    radial: new Vector3(),
+    drift: 0,
+    scatter: new Float32Array(TRAIL_POINTS * 3),
+  };
+}
+
+// Writes a random unit vector perpendicular to `normal` into `target`. Builds
+// the tangent basis from the world axis least aligned with `normal`, so it can't
+// degenerate to NaN the way `randomVector.cross(normal)` does when collinear.
+function randomTangent(normal: Vector3, target: Vector3, scratch: Vector3) {
+  const ax = Math.abs(normal.x);
+  const ay = Math.abs(normal.y);
+  const az = Math.abs(normal.z);
+  if (ax <= ay && ax <= az) scratch.set(1, 0, 0);
+  else if (ay <= az) scratch.set(0, 1, 0);
+  else scratch.set(0, 0, 1);
+
+  const tangentA = target.crossVectors(normal, scratch).normalize();
+  const tangentB = scratch.crossVectors(normal, tangentA).normalize();
+  const angle = Math.random() * Math.PI * 2;
+  return target
+    .multiplyScalar(Math.cos(angle))
+    .addScaledVector(tangentB, Math.sin(angle))
+    .normalize();
+}
+
+/**
+ * A pool of shooting-star streaks, each a bright head line trailing a scatter of
+ * fading points whose body is widest at the middle and thin at the ends. Owns
+ * its Three.js objects (a Line + a Points per slot); a consumer renders
+ * {@link objects} and calls {@link update} each frame.
+ */
+export class ShootingStars {
+  readonly objects: Object3D[];
+
+  private readonly streaks: Streak[];
+  private readonly heads: Line[];
+  private readonly trails: Points[];
+  // Reused scratch vectors so the per-frame update allocates nothing.
+  private readonly headPoint = new Vector3();
+  private readonly tailPoint = new Vector3();
+  private readonly driftOffset = new Vector3();
+
+  constructor() {
+    this.streaks = Array.from({ length: MAX_SHOOTING_STARS }, createStreak);
+    this.heads = Array.from({ length: MAX_SHOOTING_STARS }, () =>
+      this.createHead(),
+    );
+    this.trails = Array.from({ length: MAX_SHOOTING_STARS }, () =>
+      this.createTrail(),
+    );
+    this.objects = [...this.heads, ...this.trails];
+  }
+
+  /** Advances every streak one frame; `enabled` gates new spawns. */
+  update(enabled: boolean): void {
+    for (let i = 0; i < MAX_SHOOTING_STARS; i++) {
+      const streak = this.streaks[i];
+      if (!streak.active) {
+        if (enabled && Math.random() < SPAWN_CHANCE) this.spawn(streak);
+        continue;
+      }
+      this.advance(streak, this.heads[i], this.trails[i]);
+    }
+  }
+
+  /** Releases the geometries and materials owned by every streak. */
+  dispose(): void {
+    for (const object of this.objects) {
+      const renderable = object as Line | Points;
+      renderable.geometry.dispose();
+      (
+        renderable.material as LineBasicMaterial | ShootingStarTrailMaterial
+      ).dispose();
+    }
+  }
+
+  private createHead(): Line {
+    const geometry = new BufferGeometry();
+    geometry.setAttribute(
+      "position",
+      new Float32BufferAttribute([0, 0, 0, 0, 0, 0], 3),
+    );
+    const material = new LineBasicMaterial({
+      color: "#ffffff",
+      transparent: true,
+      opacity: 0,
+    });
+    const line = new Line(geometry, material);
+    // The geometry's bounding sphere is computed from the initial origin points
+    // and never recomputed as the streak moves, so without this the renderer
+    // frustum-culls the streak (thinking it's a point at the origin).
+    line.frustumCulled = false;
+    return line;
+  }
+
+  private createTrail(): Points {
+    const geometry = new BufferGeometry();
+    geometry.setAttribute(
+      "position",
+      new Float32BufferAttribute(new Float32Array(TRAIL_POINTS * 3), 3),
+    );
+    geometry.setAttribute(
+      "aWeight",
+      new Float32BufferAttribute(new Float32Array(TRAIL_POINTS), 1),
+    );
+    geometry.setAttribute(
+      "aAlpha",
+      new Float32BufferAttribute(new Float32Array(TRAIL_POINTS), 1),
+    );
+    const points = new Points(geometry, new ShootingStarTrailMaterial());
+    points.frustumCulled = false; // see createHead — bounding sphere isn't updated
+    return points;
+  }
+
+  private spawn(streak: Streak): void {
+    const radius =
+      SPAWN_RADIUS_MIN + Math.random() * (SPAWN_RADIUS_MAX - SPAWN_RADIUS_MIN);
+    randomDirection(streak.origin).multiplyScalar(radius);
+    streak.radial.copy(streak.origin).normalize();
+    randomTangent(streak.radial, streak.direction, this.tailPoint);
+    streak.length = MIN_LENGTH + Math.random() * LENGTH_RANGE;
+    streak.speed = MIN_SPEED + Math.random() * SPEED_RANGE;
+    // Signed drift in [-DRIFT_FRACTION, +DRIFT_FRACTION] * radius: nearer or farther.
+    streak.drift = (Math.random() * 2 - 1) * DRIFT_FRACTION * radius;
+    for (let i = 0; i < streak.scatter.length; i++) {
+      streak.scatter[i] = Math.random() - 0.5;
+    }
+    streak.progress = 0;
+    streak.active = true;
+  }
+
+  private advance(streak: Streak, head: Line, trail: Points): void {
+    const fadePhase =
+      streak.progress > streak.length
+        ? (streak.progress - streak.length) / (streak.length * FADE_OUT_LENGTHS)
+        : 0;
+    streak.progress += streak.speed * (1 - fadePhase * FADE_SLOWDOWN);
+
+    // Radial depth drift, eased over the streak's life (despawn distance).
+    const life = Math.min(
+      1,
+      streak.progress / (streak.length * DESPAWN_LENGTHS),
+    );
+    this.driftOffset.copy(streak.radial).multiplyScalar(streak.drift * life);
+
+    // Whole-streak fade (in over spawn, out near despawn); the head uses it as a
+    // material-wide opacity, the trail folds it into each point's aAlpha.
+    const fadeIn = Math.min(1, streak.progress / FADE_IN_DISTANCE);
+    const fadeOut = Math.max(
+      0,
+      1 -
+        (streak.progress - streak.length) / (streak.length * FADE_OUT_LENGTHS),
+    );
+    const streakOpacity = Math.min(fadeIn, fadeOut);
+
+    this.updateHeadGeometry(streak, head, fadePhase);
+    this.updateTrailGeometry(streak, trail, fadePhase, streakOpacity);
+    this.headMaterial(head).opacity = streakOpacity * HEAD_OPACITY;
+
+    if (streak.progress > streak.length * DESPAWN_LENGTHS) {
+      streak.active = false;
+      this.headMaterial(head).opacity = 0;
+    }
+  }
+
+  private updateHeadGeometry(
+    streak: Streak,
+    head: Line,
+    fadePhase: number,
+  ): void {
+    const headPos = this.headPoint
+      .copy(streak.origin)
+      .addScaledVector(streak.direction, streak.progress)
+      .add(this.driftOffset);
+    const headLen = streak.length * HEAD_LENGTH_FRACTION * (1 - fadePhase);
+    const tailPos = this.tailPoint
+      .copy(streak.origin)
+      .addScaledVector(streak.direction, Math.max(0, streak.progress - headLen))
+      .add(this.driftOffset);
+
+    const position = head.geometry.getAttribute("position");
+    position.setXYZ(0, tailPos.x, tailPos.y, tailPos.z);
+    position.setXYZ(1, headPos.x, headPos.y, headPos.z);
+    position.needsUpdate = true;
+  }
+
+  private updateTrailGeometry(
+    streak: Streak,
+    trail: Points,
+    fadePhase: number,
+    streakOpacity: number,
+  ): void {
+    const position = trail.geometry.getAttribute("position");
+    const weight = trail.geometry.getAttribute("aWeight");
+    const alpha = trail.geometry.getAttribute("aAlpha");
+    // The visible body retracts toward the head as the streak fades out.
+    const visibleLength = streak.length * (1 - fadePhase * FADE_RETRACTION);
+
+    for (let p = 0; p < TRAIL_POINTS; p++) {
+      const u = p / (TRAIL_POINTS - 1); // 0 at head, 1 at tail
+      const trailProgress = streak.progress - visibleLength * u;
+      if (trailProgress < 0) {
+        weight.setX(p, 0);
+        alpha.setX(p, 0);
+        continue;
+      }
+      const point = this.tailPoint
+        .copy(streak.origin)
+        .addScaledVector(streak.direction, trailProgress)
+        .add(this.driftOffset);
+      // Scatter grows toward the tail (u=0 is the head); each point's direction
+      // is fixed at spawn (streak.scatter) so the trail holds its shape.
+      const scatter = (1 - (1 - u) * (1 - u)) * TRAIL_SCATTER;
+      point.x += streak.scatter[p * 3] * scatter;
+      point.y += streak.scatter[p * 3 + 1] * scatter;
+      point.z += streak.scatter[p * 3 + 2] * scatter;
+      position.setXYZ(p, point.x, point.y, point.z);
+
+      // Elliptical width: widest at the midpoint (u=0.5), thin at both ends.
+      const ellipse = Math.sin(u * Math.PI);
+      weight.setX(p, TRAIL_END_WEIGHT + (1 - TRAIL_END_WEIGHT) * ellipse);
+      // Points nearer the head are brighter; the whole trail dims as it fades,
+      // both with its body retraction (fadePhase) and the streak's overall fade.
+      alpha.setX(p, (1 - u) * (1 - fadePhase) * streakOpacity * TRAIL_OPACITY);
+    }
+    position.needsUpdate = true;
+    weight.needsUpdate = true;
+    alpha.needsUpdate = true;
+  }
+
+  private headMaterial(head: Line): LineBasicMaterial {
+    return head.material as LineBasicMaterial;
+  }
+}

--- a/src/lib/Starfield.tsx
+++ b/src/lib/Starfield.tsx
@@ -1,324 +1,106 @@
-import { useRef, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useFrame } from "@react-three/fiber";
-import {
-  Float32BufferAttribute,
-  BackSide,
-  ShaderMaterial,
-  Color,
-  Vector3,
-  BufferGeometry,
-  LineBasicMaterial,
-  Line,
-  PointsMaterial,
-  Points,
-} from "three";
+import { Float32BufferAttribute, Group, Vector3 } from "three/webgpu";
 import { sceneConfig } from "./sceneConfig";
+import { randomDirection } from "./util/sphere";
+import { uTime, uSkyRotation, uTwinkle } from "./materials/sharedUniforms";
+import { GradientSkyMaterial } from "./materials/GradientSkyMaterial";
+import {
+  TwinkleStarsMaterial,
+  buildTwinkleMesh,
+} from "./materials/TwinkleStarsMaterial";
+import { ShootingStars } from "./ShootingStars";
 
 const STAR_COUNT = 2000;
 const RADIUS = 500;
-const MAX_SHOOTING_STARS = 3;
-const SPAWN_CHANCE = 0.003;
-const TRAIL_POINTS = 20;
+// The sky sphere is drawn slightly outside the star shell.
+const SKY_SPHERE_RADIUS = RADIUS * 1.2;
+// Most stars are small; a few percent are noticeably larger.
+const LARGE_STAR_CHANCE = 0.92;
+// Seconds-to-radians scale for the sky's slow rotation.
+const SKY_ROTATION_SCALE = 60;
 
-const gradientMaterial = new ShaderMaterial({
-  side: BackSide,
-  depthWrite: false,
-  uniforms: {
-    colorA: { value: new Color("#007ba7") },
-    colorB: { value: new Color("#6f456e") },
-    uTime: { value: 0 },
-  },
-  vertexShader: `
-        varying vec3 vWorldPos;
-        void main() {
-            vWorldPos = (modelMatrix * vec4(position, 1.0)).xyz;
-            gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
-        }
-    `,
-  fragmentShader: `
-        uniform vec3 colorA;
-        uniform vec3 colorB;
-        uniform float uTime;
-        varying vec3 vWorldPos;
-        void main() {
-            vec3 dir = normalize(vWorldPos);
-            float c = cos(uTime);
-            float s = sin(uTime);
-            vec3 rotDir = vec3(
-                dir.x * c + dir.y * s,
-                -dir.x * s + dir.y * c,
-                dir.z
-            );
-            float t = clamp(dot(rotDir, normalize(vec3(1.0, -1.0, 0.0))) * 0.78 + 0.72, 0.0, 1.0);
-            vec3 bg = mix(colorA, colorB, t);
-            bg *= 0.14;
-            gl_FragColor = vec4(bg, 1.0);
-        }
-    `,
-});
-
-interface ShootingStar {
-  active: boolean;
-  progress: number;
-  speed: number;
-  origin: Vector3;
-  direction: Vector3;
-  length: number;
+interface StarData {
+  positions: Float32BufferAttribute;
+  sizes: Float32BufferAttribute;
 }
 
-function generateStarData() {
-  const pos = new Float32Array(STAR_COUNT * 3);
+function generateStarData(): StarData {
+  const positions = new Float32Array(STAR_COUNT * 3);
   const sizes = new Float32Array(STAR_COUNT);
+  const dir = new Vector3();
   for (let i = 0; i < STAR_COUNT; i++) {
-    const theta = Math.random() * Math.PI * 2;
-    const phi = Math.acos(2 * Math.random() - 1);
     const r = RADIUS * (0.8 + 0.2 * Math.random());
-    pos[i * 3] = r * Math.sin(phi) * Math.cos(theta);
-    pos[i * 3 + 1] = r * Math.sin(phi) * Math.sin(theta);
-    pos[i * 3 + 2] = r * Math.cos(phi);
+    randomDirection(dir).multiplyScalar(r);
+    positions[i * 3] = dir.x;
+    positions[i * 3 + 1] = dir.y;
+    positions[i * 3 + 2] = dir.z;
     const rnd = Math.random();
-    sizes[i] = rnd < 0.92 ? 0.3 + rnd * 0.4 : 1.0 + Math.pow(rnd, 3) * 2.0;
+    sizes[i] =
+      rnd < LARGE_STAR_CHANCE ? 0.3 + rnd * 0.4 : 1.0 + Math.pow(rnd, 3) * 2.0;
   }
   return {
-    positions: new Float32BufferAttribute(pos, 3),
+    positions: new Float32BufferAttribute(positions, 3),
     sizes: new Float32BufferAttribute(sizes, 1),
   };
 }
 
 export default function Starfield() {
   const [{ positions, sizes }] = useState(generateStarData);
-
-  const shootingStars = useRef<ShootingStar[]>(
-    Array.from({ length: MAX_SHOOTING_STARS }, () => ({
-      active: false,
-      progress: 0,
-      speed: 0,
-      origin: new Vector3(),
-      direction: new Vector3(),
-      length: 0,
-    })),
+  // The sky sphere + stars recenter on the camera each frame so they read as an
+  // infinitely-distant backdrop: only camera rotation moves them, not translation,
+  // so flying forward no longer brings the stars closer / makes them grow.
+  const domeRef = useRef<Group>(null!);
+  const gradientMaterial = useMemo(() => new GradientSkyMaterial(), []);
+  const twinkleMaterial = useMemo(() => new TwinkleStarsMaterial(), []);
+  const twinkleMesh = useMemo(
+    () => buildTwinkleMesh(positions, sizes, twinkleMaterial),
+    [positions, sizes, twinkleMaterial],
   );
+  const shootingStars = useMemo(() => new ShootingStars(), []);
 
-  const headRefs = useRef<(Line | null)[]>([]);
-  const trailRefs = useRef<(Points | null)[]>([]);
+  useEffect(() => {
+    uTwinkle.value = sceneConfig.twinkle ? 1 : 0;
+  }, []);
 
-  const headGeometries = useMemo(
-    () =>
-      Array.from({ length: MAX_SHOOTING_STARS }, () => {
-        const geo = new BufferGeometry();
-        geo.setAttribute(
-          "position",
-          new Float32BufferAttribute([0, 0, 0, 0, 0, 0], 3),
-        );
-        return geo;
-      }),
-    [],
-  );
-
-  const trailGeometries = useMemo(
-    () =>
-      Array.from({ length: MAX_SHOOTING_STARS }, () => {
-        const geo = new BufferGeometry();
-        const pos = new Float32Array(TRAIL_POINTS * 3);
-        const sizes = new Float32Array(TRAIL_POINTS);
-        geo.setAttribute("position", new Float32BufferAttribute(pos, 3));
-        geo.setAttribute("size", new Float32BufferAttribute(sizes, 1));
-        return geo;
-      }),
-    [],
-  );
-
-  const headMaterial = useMemo(
-    () =>
-      new LineBasicMaterial({
-        color: "#ffffff",
-        transparent: true,
-        opacity: 0,
-      }),
-    [],
-  );
-
-  const trailMaterial = useMemo(
-    () =>
-      new PointsMaterial({
-        color: "#ffffff",
-        size: 0.6,
-        transparent: true,
-        opacity: 0,
-        sizeAttenuation: true,
-      }),
-    [],
-  );
-
-  const headObjects = useMemo(
-    () => headGeometries.map((geo) => new Line(geo, headMaterial.clone())),
-    [headGeometries, headMaterial],
-  );
-
-  const trailObjects = useMemo(
-    () => trailGeometries.map((geo) => new Points(geo, trailMaterial.clone())),
-    [trailGeometries, trailMaterial],
+  // r3f doesn't dispose <primitive> objects or detached materials, so release
+  // the GPU resources this component owns when it unmounts.
+  useEffect(
+    () => () => {
+      twinkleMesh.geometry.dispose();
+      gradientMaterial.dispose();
+      twinkleMaterial.dispose();
+      shootingStars.dispose();
+    },
+    [twinkleMesh, gradientMaterial, twinkleMaterial, shootingStars],
   );
 
   useFrame((state) => {
+    // uTime always advances so the twinkle keeps animating; the sky rotation
+    // tracks the same value but only while enabled, holding its last angle when
+    // disabled instead of freezing the twinkle too.
+    const time = -state.elapsed / SKY_ROTATION_SCALE;
+    uTime.value = time;
     if (sceneConfig.gradientRotation) {
-      gradientMaterial.uniforms.uTime.value = -state.elapsed / 60;
+      uSkyRotation.value = time;
     }
-
-    const stars = shootingStars.current;
-
-    for (let i = 0; i < MAX_SHOOTING_STARS; i++) {
-      const s = stars[i];
-      const head = headRefs.current[i];
-      const trail = trailRefs.current[i];
-      if (!head || !trail) continue;
-
-      if (!s.active) {
-        if (sceneConfig.shootingStars && Math.random() < SPAWN_CHANCE) {
-          const theta = Math.random() * Math.PI * 2;
-          const phi = Math.acos(2 * Math.random() - 1);
-          const r = RADIUS * 0.85;
-          s.origin.set(
-            r * Math.sin(phi) * Math.cos(theta),
-            r * Math.sin(phi) * Math.sin(theta),
-            r * Math.cos(phi),
-          );
-          const tangent = new Vector3(
-            Math.random() - 0.5,
-            Math.random() - 0.5,
-            Math.random() - 0.5,
-          )
-            .cross(s.origin)
-            .normalize();
-          s.direction.copy(tangent);
-          s.length = 12 + Math.random() * 8;
-          s.speed = 0.4 + Math.random() * 0.4;
-          s.progress = 0;
-          s.active = true;
-        }
-        continue;
-      }
-
-      const fadePhase =
-        s.progress > s.length ? (s.progress - s.length) / (s.length * 3) : 0;
-      s.progress += s.speed * (1 - fadePhase * 0.8);
-
-      const headPos = s.origin.clone().addScaledVector(s.direction, s.progress);
-      const headLen = s.length * 0.3 * (1 - fadePhase);
-      const tailPos = s.origin
-        .clone()
-        .addScaledVector(s.direction, Math.max(0, s.progress - headLen));
-
-      const posAttr = headGeometries[i].getAttribute("position");
-      posAttr.setXYZ(0, tailPos.x, tailPos.y, tailPos.z);
-      posAttr.setXYZ(1, headPos.x, headPos.y, headPos.z);
-      posAttr.needsUpdate = true;
-
-      const trailPosAttr = trailGeometries[i].getAttribute("position");
-      for (let p = 0; p < TRAIL_POINTS; p++) {
-        const t = p / TRAIL_POINTS;
-        const trailProgress = s.progress - s.length * t;
-        if (trailProgress < 0) {
-          trailPosAttr.setXYZ(p, 0, 0, -9999);
-        } else {
-          const pt = s.origin
-            .clone()
-            .addScaledVector(s.direction, trailProgress);
-          const scatter = (1 - (1 - t) * (1 - t)) * 0.8;
-          pt.x += (Math.random() - 0.5) * scatter;
-          pt.y += (Math.random() - 0.5) * scatter;
-          pt.z += (Math.random() - 0.5) * scatter;
-          trailPosAttr.setXYZ(p, pt.x, pt.y, pt.z);
-        }
-      }
-      trailPosAttr.needsUpdate = true;
-
-      const fadeIn = Math.min(1, s.progress / 5);
-      const fadeOut = Math.max(0, 1 - (s.progress - s.length) / (s.length * 3));
-      const opacity = Math.min(fadeIn, fadeOut);
-
-      (head.material as LineBasicMaterial).opacity = opacity * 0.9;
-      (trail.material as PointsMaterial).opacity = opacity * 0.4;
-      (trail.material as PointsMaterial).size = 0.4;
-
-      if (s.progress > s.length * 4) {
-        s.active = false;
-        (head.material as LineBasicMaterial).opacity = 0;
-        (trail.material as PointsMaterial).opacity = 0;
-      }
-    }
+    // Keep the dome centered on the camera so the backdrop stays at a fixed
+    // distance (and screen size) regardless of how far the camera flies.
+    domeRef.current.position.copy(state.camera.position);
+    shootingStars.update(sceneConfig.shootingStars);
   });
 
+  // Camera-following distant backdrop (sky + stars + shooting stars), so the
+  // backdrop stays a consistent distance and isn't fogged into oblivion as the
+  // camera flies.
   return (
-    <group>
+    <group ref={domeRef}>
       <mesh material={gradientMaterial}>
-        <sphereGeometry args={[RADIUS * 1.2, 32, 32]} />
+        <sphereGeometry args={[SKY_SPHERE_RADIUS, 32, 32]} />
       </mesh>
-      <points>
-        <bufferGeometry>
-          <bufferAttribute attach="attributes-position" {...positions} />
-          <bufferAttribute attach="attributes-aSize" {...sizes} />
-        </bufferGeometry>
-        {sceneConfig.twinkle ? (
-          <shaderMaterial
-            transparent
-            depthWrite={false}
-            uniforms={{
-              uTime: gradientMaterial.uniforms.uTime,
-            }}
-            vertexShader={`
-              attribute float aSize;
-              uniform float uTime;
-              varying float vAlpha;
-              varying float vBrightness;
-              void main() {
-                vec4 mvPos = modelViewMatrix * vec4(position, 1.0);
-                float seed = mod(abs(position.x * 73.17 + position.y * 91.31 + position.z * 37.19), 6.2831);
-                float twinkle = sin(uTime * 40.0 + seed);
-                vAlpha = (0.35 + 0.25 * aSize) + 0.2 * twinkle;
-                vBrightness = 0.6 + 0.4 * smoothstep(0.7, 2.0, aSize);
-                gl_PointSize = aSize * (1.0 + 0.15 * twinkle) * (300.0 / -mvPos.z);
-                gl_Position = projectionMatrix * mvPos;
-              }
-            `}
-            fragmentShader={`
-              varying float vAlpha;
-              varying float vBrightness;
-              void main() {
-                float d = length(gl_PointCoord - vec2(0.5));
-                if (d > 0.5) discard;
-                float alpha = vAlpha * smoothstep(0.5, 0.1, d);
-                gl_FragColor = vec4(vec3(vBrightness), alpha);
-              }
-            `}
-          />
-        ) : (
-          <pointsMaterial
-            size={0.8}
-            color="#ffffff"
-            sizeAttenuation
-            transparent
-            opacity={0.7}
-          />
-        )}
-      </points>
-      {headObjects.map((obj, i) => (
-        <primitive
-          key={`head-${i}`}
-          object={obj}
-          ref={(el: Line | null) => {
-            headRefs.current[i] = el;
-          }}
-        />
-      ))}
-      {trailObjects.map((obj, i) => (
-        <primitive
-          key={`trail-${i}`}
-          object={obj}
-          ref={(el: Points | null) => {
-            trailRefs.current[i] = el;
-          }}
-        />
+      <primitive object={twinkleMesh} />
+      {shootingStars.objects.map((object, i) => (
+        <primitive key={i} object={object} />
       ))}
     </group>
   );

--- a/src/lib/materials/EmissiveStarMaterial.ts
+++ b/src/lib/materials/EmissiveStarMaterial.ts
@@ -1,0 +1,45 @@
+import { Color, MeshStandardNodeMaterial } from "three/webgpu";
+import { varyingProperty, vec3, max, mix } from "three/tsl";
+
+// Floor on the instance color so the base-color division never hits zero.
+const MIN_INSTANCE_CHANNEL = 0.001;
+
+interface EmissiveStarOptions {
+  /** Instance-color tint of the lit albedo: 0 = white, 1 = fully saturated. */
+  baseTint?: number;
+  /** Strength of the per-instance colored emissive glow (feeds bloom). */
+  emissiveIntensity?: number;
+}
+
+/**
+ * Material for the helix star particles, used with drei's <Instances>. The
+ * per-instance color mostly drives the emissive glow while the lit albedo stays
+ * near-white (the original MeshStandardMaterial + `totalEmissiveRadiance *=
+ * vColor` look).
+ *
+ * three's instancing node multiplies the instance color into the base color with
+ * no opt-out, so we set `colorNode = desiredBase / vInstanceColor` — the
+ * auto-multiply then resolves back to `desiredBase`, a mostly-white pastel blend.
+ */
+export class EmissiveStarMaterial extends MeshStandardNodeMaterial {
+  constructor({
+    baseTint = 0.67,
+    // High enough that the per-particle glow clears the bloom threshold on its
+    // own — so bloom reads consistently whether or not the directional light is
+    // dimming/shaping the lit albedo.
+    emissiveIntensity = 0.6,
+  }: EmissiveStarOptions = {}) {
+    super({
+      emissive: new Color("#ffffff"),
+      roughness: 0.3,
+      metalness: 0.1,
+    });
+
+    const instanceColor = varyingProperty("vec3", "vInstanceColor");
+    const safeInstanceColor = max(instanceColor, vec3(MIN_INSTANCE_CHANNEL));
+    const desiredBase = mix(vec3(1, 1, 1), instanceColor, baseTint);
+
+    this.colorNode = desiredBase.div(safeInstanceColor);
+    this.emissiveNode = instanceColor.mul(emissiveIntensity);
+  }
+}

--- a/src/lib/materials/GradientSkyMaterial.ts
+++ b/src/lib/materials/GradientSkyMaterial.ts
@@ -1,0 +1,68 @@
+import { BackSide, MeshBasicNodeMaterial } from "three/webgpu";
+import {
+  positionLocal,
+  normalize,
+  dot,
+  clamp,
+  mix,
+  sin,
+  cos,
+  vec3,
+  Fn,
+} from "three/tsl";
+import { uSkyRotation } from "./sharedUniforms";
+
+const SKY_COLOR_A = vec3(0 / 255, 123 / 255, 167 / 255); // #007ba7
+const SKY_COLOR_B = vec3(111 / 255, 69 / 255, 110 / 255); // #6f456e
+
+// Axis the rotated view direction projects onto, then a slope/offset that remap
+// that projection into [0, 1] for the blue->purple mix.
+const GRADIENT_AXIS = normalize(vec3(1.0, -1.0, 0.0));
+const GRADIENT_SLOPE = 0.45;
+const GRADIENT_OFFSET = 0.8;
+
+// Near-black deep-space floor the gradient is diffused into.
+const SKY_FLOOR = vec3(1 / 255, 2 / 255, 6 / 255);
+// How much of the vibrant blue->purple gradient shows through the black floor.
+// Low so black dominates everywhere; the colors are a subtle, diffused tint
+// rather than a bright band — so the middle never blows out.
+const COLOR_AMOUNT = 0.068;
+
+/**
+ * Background sky: a slowly rotating two-color gradient on the inside of the star
+ * sphere. Rotates the world-space view direction around Z by
+ * {@link uSkyRotation}, projects it onto {@link GRADIENT_AXIS}, and mixes the
+ * sky colors by it.
+ */
+export class GradientSkyMaterial extends MeshBasicNodeMaterial {
+  constructor() {
+    super();
+    this.side = BackSide;
+    this.depthWrite = false;
+    // The sky is the backdrop; its darkness is baked into the gradient, so it
+    // shouldn't be re-darkened by distance fog (which varies with camera position
+    // and caused a bright/uneven edge against the fogged scene).
+    this.fog = false;
+    this.colorNode = Fn(() => {
+      // Local (not world) direction so the gradient is orientation-only — stable
+      // as the sky sphere translates to follow the camera (see Starfield).
+      const dir = normalize(positionLocal);
+      const c = cos(uSkyRotation);
+      const s = sin(uSkyRotation);
+      const rotatedDir = vec3(
+        dir.x.mul(c).add(dir.y.mul(s)),
+        dir.x.mul(s).negate().add(dir.y.mul(c)),
+        dir.z,
+      );
+      const along = dot(rotatedDir, GRADIENT_AXIS); // [-1, 1] along the axis
+      const t = clamp(along.mul(GRADIENT_SLOPE).add(GRADIENT_OFFSET), 0.0, 1.0);
+
+      // Vibrant blue->purple gradient, diffused into the near-black floor by a low
+      // COLOR_AMOUNT so black dominates everywhere and the colors read as a subtle
+      // deep-space tint — never a bright band in the middle. Banding handled by
+      // the output dither (see SceneEffects).
+      const gradient = mix(SKY_COLOR_A, SKY_COLOR_B, t);
+      return mix(SKY_FLOOR, gradient, COLOR_AMOUNT);
+    })();
+  }
+}

--- a/src/lib/materials/ShootingStarTrailMaterial.ts
+++ b/src/lib/materials/ShootingStarTrailMaterial.ts
@@ -1,0 +1,32 @@
+import { PointsNodeMaterial } from "three/webgpu";
+import { attribute, vec3 } from "three/tsl";
+
+// Base sprite size; the per-point `aWeight` attribute scales it so the trail is
+// widest at its midpoint and tapers thin at the head and tail (elliptical).
+const SPRITE_SIZE = 0.9;
+
+/**
+ * Trail points for a shooting star. A {@link PointsNodeMaterial} in sprite mode
+ * (so sizeNode is honored on WebGPU) reading per-point attributes set by
+ * {@link ShootingStars}: `aWeight` shapes the elliptical profile (thin ends, wide
+ * middle) and `aAlpha` carries the per-point opacity so individual points fade.
+ *
+ * Unlike the twinkle stars this draws a raw THREE.Points (no plane geometry, so
+ * no `uv`), so it can't sample a uv-based round mask — the dots are small and
+ * bloom-blurred, so the plain square sprite reads as a soft point regardless.
+ */
+export class ShootingStarTrailMaterial extends PointsNodeMaterial {
+  constructor() {
+    super();
+    this.transparent = true;
+    this.depthWrite = false;
+    this.sizeAttenuation = true;
+
+    const aWeight = attribute<"float">("aWeight", "float");
+    const aAlpha = attribute<"float">("aAlpha", "float");
+
+    this.sizeNode = aWeight.mul(SPRITE_SIZE);
+    this.colorNode = vec3(1.0);
+    this.opacityNode = aAlpha;
+  }
+}

--- a/src/lib/materials/TwinkleStarsMaterial.ts
+++ b/src/lib/materials/TwinkleStarsMaterial.ts
@@ -1,0 +1,141 @@
+import {
+  Float32BufferAttribute,
+  InstancedBufferAttribute,
+  InstancedMesh,
+  Object3D,
+  PlaneGeometry,
+  PointsNodeMaterial,
+} from "three/webgpu";
+import {
+  sin,
+  fract,
+  smoothstep,
+  vec2,
+  vec3,
+  float,
+  attribute,
+  uv,
+  distance,
+} from "three/tsl";
+import { uTime, uTwinkle } from "./sharedUniforms";
+
+// Per-star twinkle phase, derived from position to match the original GLSL seed.
+const SEED_X = 73.17;
+const SEED_Y = 91.31;
+const SEED_Z = 37.19;
+const SEED_PERIOD = 6.2831; // ~2π
+
+const TWINKLE_SPEED = 40.0;
+const TWINKLE_SIZE_AMOUNT = 0.25;
+const TWINKLE_ALPHA_AMOUNT = 0.45;
+
+// With sizeAttenuation the sprite path treats this like a screen-space point
+// size (gl_PointSize convention), so it is resolution dependent, not world
+// units. Reconciles the original GLSL `300.0 / -mvPos.z` point size.
+const SPRITE_SIZE = 0.0027;
+
+const ALPHA_BASE = 0.35;
+const ALPHA_SIZE_SCALE = 0.25;
+
+// Each star gets a fixed baseline brightness drawn from its seed (so brightness
+// varies star-to-star, not just by size), spanning MIN..MIN+RANGE. Larger stars
+// get an extra lift on top via the size smoothstep.
+const BRIGHTNESS_MIN = 0.35;
+const BRIGHTNESS_RANGE = 0.55;
+const SIZE_BRIGHTNESS_LIFT = 0.3;
+const SIZE_FADE_START = 0.7;
+const SIZE_FADE_END = 2.0;
+
+// Round sprite radius in uv space (centered at 0.5): soft falloff to POINT_CORE,
+// hard cutoff at POINT_EDGE.
+const POINT_RADIUS = 0.5;
+const POINT_CORE = 0.1;
+const POINT_EDGE = 0.49;
+
+/**
+ * Twinkling background stars. WebGPU renders native THREE.Points at a fixed 1px
+ * regardless of sizeNode, so the stars are instanced billboard sprites instead:
+ * a PointsNodeMaterial in sprite mode (on an InstancedMesh of a unit plane),
+ * which honors sizeNode on both backends. Per-star size and twinkle phase come
+ * from the `aSize` / `aSeed` attributes built in {@link buildTwinkleMesh}.
+ */
+export class TwinkleStarsMaterial extends PointsNodeMaterial {
+  constructor() {
+    super();
+    this.transparent = true;
+    this.depthWrite = false;
+    this.sizeAttenuation = true;
+
+    const aSize = attribute<"float">("aSize", "float");
+    const aSeed = attribute<"float">("aSeed", "float");
+    // uTwinkle (0/1) scales the oscillation so the stars can be held steady.
+    const twinkle = sin(uTime.mul(TWINKLE_SPEED).add(aSeed)).mul(uTwinkle);
+
+    this.sizeNode = aSize
+      .mul(float(1.0).add(twinkle.mul(TWINKLE_SIZE_AMOUNT)))
+      .mul(SPRITE_SIZE);
+
+    const alpha = float(ALPHA_BASE)
+      .add(aSize.mul(ALPHA_SIZE_SCALE))
+      .add(twinkle.mul(TWINKLE_ALPHA_AMOUNT));
+    // Per-star baseline from the seed (fract gives a stable 0..1 per star), so
+    // brightness varies between stars; larger stars get an additional lift.
+    const seedBrightness = fract(aSeed.mul(SEED_X));
+    const brightness = float(BRIGHTNESS_MIN)
+      .add(seedBrightness.mul(BRIGHTNESS_RANGE))
+      .add(
+        smoothstep(SIZE_FADE_START, SIZE_FADE_END, aSize).mul(
+          SIZE_BRIGHTNESS_LIFT,
+        ),
+      );
+
+    // Sprite mode uses the plane's own uv, not pointUV: pointUV generates
+    // `gl_PointCoord`, which is invalid on WGSL and only valid for native points.
+    const radial = distance(uv(), vec2(POINT_RADIUS));
+    this.colorNode = vec3(brightness);
+    // Soft falloff times a hard cutoff, replacing the original `if (d>0.5) discard`.
+    this.opacityNode = alpha
+      .mul(smoothstep(POINT_RADIUS, POINT_CORE, radial))
+      .mul(smoothstep(POINT_RADIUS, POINT_EDGE, radial));
+  }
+}
+
+/**
+ * Builds the {@link TwinkleStarsMaterial}'s instanced mesh: one unit-plane
+ * instance per star, positioned at its location with `aSize` / `aSeed` attributes.
+ */
+export function buildTwinkleMesh(
+  positions: Float32BufferAttribute,
+  sizes: Float32BufferAttribute,
+  material: TwinkleStarsMaterial,
+): InstancedMesh {
+  const count = sizes.count;
+  const sizeAttr = new Float32Array(count);
+  const seedAttr = new Float32Array(count);
+  for (let i = 0; i < count; i++) {
+    sizeAttr[i] = sizes.getX(i);
+    const x = positions.getX(i);
+    const y = positions.getY(i);
+    const z = positions.getZ(i);
+    seedAttr[i] = Math.abs(x * SEED_X + y * SEED_Y + z * SEED_Z) % SEED_PERIOD;
+  }
+
+  const geometry = new PlaneGeometry(1, 1);
+  geometry.setAttribute("aSize", new InstancedBufferAttribute(sizeAttr, 1));
+  geometry.setAttribute("aSeed", new InstancedBufferAttribute(seedAttr, 1));
+
+  const mesh = new InstancedMesh(geometry, material, count);
+  const placement = new Object3D();
+  for (let i = 0; i < count; i++) {
+    placement.position.set(
+      positions.getX(i),
+      positions.getY(i),
+      positions.getZ(i),
+    );
+    placement.updateMatrix();
+    mesh.setMatrixAt(i, placement.matrix);
+  }
+  mesh.instanceMatrix.needsUpdate = true;
+  mesh.frustumCulled = false;
+  return mesh;
+}

--- a/src/lib/materials/dither.ts
+++ b/src/lib/materials/dither.ts
@@ -1,0 +1,28 @@
+import { screenCoordinate, dot, sin, fract, vec2 } from "three/tsl";
+import type { Node } from "three/webgpu";
+
+type ColorNode = Node<"vec4">;
+
+// Standard hash constants for fract(sin(dot(...))) value noise.
+const HASH_DOT = vec2(12.9898, 78.233);
+const HASH_SCALE = 43758.5453;
+
+// Dither amplitude in linear space (applied before the pipeline's tone-map +
+// sRGB encode). Half a quantization step is enough to dissolve 8-bit banding in
+// the smooth dark ramps while staying below the threshold of visible grain.
+// Raise if bands persist, lower if it looks noisy.
+const DITHER_AMOUNT = 1 / 255;
+
+/**
+ * Adds triangular-PDF dither to a color node: two independent per-pixel hashes
+ * differenced, giving noise in (-1, 1) with a flat floor, scaled to ~one
+ * quantization step. Texture-free. Apply to the final output so it covers
+ * everything that quantizes (fog, gradient, bloom).
+ */
+export function dithered(color: ColorNode): ColorNode {
+  const coord = screenCoordinate.xy;
+  const r1 = fract(sin(dot(coord, HASH_DOT)).mul(HASH_SCALE));
+  const r2 = fract(sin(dot(coord.add(1.0), HASH_DOT)).mul(HASH_SCALE));
+  const dither = r1.sub(r2).mul(DITHER_AMOUNT);
+  return color.add(dither);
+}

--- a/src/lib/materials/sharedUniforms.ts
+++ b/src/lib/materials/sharedUniforms.ts
@@ -1,0 +1,12 @@
+import { uniform } from "three/tsl";
+
+// Always-advancing animated time, written each frame in Starfield. Drives the
+// twinkle animation (and is read by the gradient sky too).
+export const uTime = uniform(0);
+
+// Sky-gradient rotation angle. Advances only while sceneConfig.gradientRotation
+// is on, so disabling sky rotation doesn't also freeze the star twinkle.
+export const uSkyRotation = uniform(0);
+
+// Twinkle strength multiplier (1 = on, 0 = steady stars), from sceneConfig.twinkle.
+export const uTwinkle = uniform(1);

--- a/src/lib/sceneConfig.ts
+++ b/src/lib/sceneConfig.ts
@@ -1,3 +1,10 @@
+// How the particle rainbow is distributed across the tornado:
+//  - solid:  every particle shares one cycling color
+//  - band:   color offset advances along the helix (banded revolutions)
+//  - stripe: color offset follows the angle around the axis (radial stripes)
+export type ColorLerpStyle = "solid" | "band" | "stripe";
+export const COLOR_LERP_STYLES: ColorLerpStyle[] = ["solid", "band", "stripe"];
+
 export interface SceneConfig {
   bloom: boolean;
   fog: boolean;
@@ -5,13 +12,18 @@ export interface SceneConfig {
   sceneBackground: boolean;
   toneMapping: boolean;
   emissiveStars: boolean;
+  /** @deprecated No TSL/WebGPU equivalent; inert after the WebGPU migration. */
   depthOfField: boolean;
   shootingStars: boolean;
   twinkle: boolean;
   gradientRotation: boolean;
+  colorLerpStyle: ColorLerpStyle;
 }
 
-export const SCENE_BG_COLOR = "#070b1a";
+// Near-black with a faint blue tint matching the sky's dark floor, so fog fades
+// distant content into the background instead of to a flat black that would
+// stand out against the sky.
+export const SCENE_BG_COLOR = "#1c1f29";
 
 export const sceneConfig: SceneConfig = {
   bloom: true,
@@ -24,4 +36,23 @@ export const sceneConfig: SceneConfig = {
   shootingStars: true,
   twinkle: true,
   gradientRotation: true,
+  colorLerpStyle: "band",
 };
+
+// Randomize the particle color style on each page load.
+sceneConfig.colorLerpStyle =
+  COLOR_LERP_STYLES[Math.floor(Math.random() * COLOR_LERP_STYLES.length)];
+
+// The boolean (toggleable) keys of SceneConfig.
+export type BooleanConfigKey = {
+  [K in keyof SceneConfig]: SceneConfig[K] extends boolean ? K : never;
+}[keyof SceneConfig];
+
+/** Flips a boolean scene option in place (used by the admin config panel). */
+export function toggleSceneOption(key: BooleanConfigKey): void {
+  sceneConfig[key] = !sceneConfig[key];
+}
+
+export function setColorLerpStyle(style: ColorLerpStyle): void {
+  sceneConfig.colorLerpStyle = style;
+}

--- a/src/lib/util/colorLerp.ts
+++ b/src/lib/util/colorLerp.ts
@@ -1,5 +1,5 @@
-import { Color } from "three";
-import { TrimmedColor, lerp } from "./util";
+import { Color, SRGBColorSpace } from "three";
+import { lerp, TrimmedColor } from "./util";
 
 export const rainbowColors: TrimmedColor[] = [
   { r: 255, g: 0, b: 0 },
@@ -19,49 +19,51 @@ export const pastelRainbowColors: TrimmedColor[] = [
   { r: 255, g: 100, b: 255 },
 ];
 
-export interface ColorLerpProp {
-  colorLerp: ColorLerp;
-}
-
+/**
+ * A continuous loop through a palette. `phase` is measured in palette segments,
+ * so phase N..N+1 interpolates colors[N]..colors[N+1], wrapping at the end.
+ * Sampling is pure ({@link sampleInto} writes into a caller-owned Color), so a
+ * single instance can color many objects at different phase offsets without
+ * per-call allocations.
+ */
 export class ColorLerp {
-  private colors: TrimmedColor[];
-  private currentColor: TrimmedColor;
-  private idx: number;
-  private lerpVal: number;
-  private lerpAmt: number;
+  private readonly colors: TrimmedColor[];
+  private readonly speed: number;
+  private phaseValue: number;
 
-  constructor(colors: TrimmedColor[], lerpAmt = 0.001) {
+  constructor(colors: TrimmedColor[], speed = 0.001) {
     this.colors = colors;
-    const idx = Math.floor(Math.random() * (colors.length - 1));
-    this.currentColor = new Color(colors[idx].r, colors[idx].g, colors[idx].b);
-    this.idx = idx;
-    this.lerpVal = 0;
-    this.lerpAmt = lerpAmt;
+    this.speed = speed;
+    this.phaseValue = Math.random() * colors.length;
   }
 
-  public get color(): TrimmedColor {
-    return this.currentColor;
+  /** Current loop position, in palette segments. */
+  get phase(): number {
+    return this.phaseValue;
   }
 
-  public step(): TrimmedColor {
-    this.lerpVal = Math.min(1, this.lerpVal + this.lerpAmt);
-    if (this.lerpVal >= 1) {
-      this.idx = (this.idx + 1) % this.colors.length;
-      this.lerpVal = 0;
-    }
+  /** Advance the loop by one step. */
+  step(): void {
+    this.phaseValue = (this.phaseValue + this.speed) % this.colors.length;
+  }
 
-    const nextIndex = this.idx === this.colors.length - 1 ? 0 : this.idx + 1;
-    const currentColor = this.colors[this.idx];
-    const nextColor = this.colors[nextIndex];
-    this.currentColor.r = Math.round(
-      lerp(currentColor.r, nextColor.r, this.lerpVal),
+  /**
+   * Writes the palette color at `phase` (segments, any real value — wrapped)
+   * into `target`. The palette is authored in sRGB (like the old CSS-string
+   * path), so it's interpreted as such. Does not allocate.
+   */
+  sampleInto(phase: number, target: Color): Color {
+    const n = this.colors.length;
+    const wrapped = ((phase % n) + n) % n;
+    const i = Math.floor(wrapped);
+    const frac = wrapped - i;
+    const a = this.colors[i];
+    const b = this.colors[(i + 1) % n];
+    return target.setRGB(
+      lerp(a.r, b.r, frac) / 255,
+      lerp(a.g, b.g, frac) / 255,
+      lerp(a.b, b.b, frac) / 255,
+      SRGBColorSpace,
     );
-    this.currentColor.g = Math.round(
-      lerp(currentColor.g, nextColor.g, this.lerpVal),
-    );
-    this.currentColor.b = Math.round(
-      lerp(currentColor.b, nextColor.b, this.lerpVal),
-    );
-    return this.currentColor;
   }
 }

--- a/src/lib/util/sphere.ts
+++ b/src/lib/util/sphere.ts
@@ -1,0 +1,17 @@
+import { Vector3 } from "three";
+
+/**
+ * Writes a uniformly-distributed random unit vector (a point on the unit sphere)
+ * into `target` and returns it. Uses the standard inverse-CDF sampling so the
+ * directions don't bunch at the poles.
+ */
+export function randomDirection(target: Vector3): Vector3 {
+  const theta = Math.random() * Math.PI * 2;
+  const phi = Math.acos(2 * Math.random() - 1);
+  const sinPhi = Math.sin(phi);
+  return target.set(
+    sinPhi * Math.cos(theta),
+    sinPhi * Math.sin(theta),
+    Math.cos(phi),
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,18 +2,42 @@ import styles from "../styles/Home.module.css";
 import dynamic from "next/dynamic";
 import { Suspense, useState } from "react";
 import EggController, { EggKeys } from "../lib/EggController";
+import LoadingSkeleton from "../lib/LoadingSkeleton";
+import SceneConfigPanel from "../lib/SceneConfigPanel";
 import { sceneConfig } from "../lib/sceneConfig";
+import {
+  ACESFilmicToneMapping,
+  NoToneMapping,
+  PCFSoftShadowMap,
+} from "three/webgpu";
 
 const Canvas = dynamic(
-  () => import("@react-three/fiber").then((mod) => mod.Canvas),
+  () => import("@react-three/fiber/webgpu").then((mod) => mod.Canvas),
   { ssr: false },
 );
 const DynamicScene = dynamic(() => import("../lib/DynamicScene"), {
   ssr: false,
 });
 
+// WebGPURenderer transparently falls back to its WebGL2 backend when WebGPU is
+// unavailable, so a single renderer covers both paths. TSL node materials run
+// on either backend.
+const createRenderer = (props: { canvas: HTMLCanvasElement }) =>
+  import("three/webgpu").then(({ WebGPURenderer }) => {
+    const renderer = new WebGPURenderer({ ...props, antialias: true });
+    renderer.toneMapping = sceneConfig.toneMapping
+      ? ACESFilmicToneMapping
+      : NoToneMapping;
+    renderer.toneMappingExposure = 0.85;
+    return renderer;
+  });
+
 export default function Home() {
   const [adminEnabled, setAdminEnabled] = useState(false);
+  const [sceneReady, setSceneReady] = useState(false);
+  // Bumped whenever a scene option toggles, to remount the scene so it re-reads
+  // the (module-level) sceneConfig.
+  const [configVersion, setConfigVersion] = useState(0);
 
   const keyMapping = {
     [EggKeys.SLYFOX]: setAdminEnabled,
@@ -23,15 +47,24 @@ export default function Home() {
     <div className={styles.root}>
       <Canvas
         style={{ position: "relative" }}
-        flat={!sceneConfig.toneMapping}
-        shadows={sceneConfig.directionalLight ? "soft" : undefined}
-        gl={sceneConfig.toneMapping ? { toneMappingExposure: 0.85 } : undefined}
+        renderer={createRenderer}
+        shadows={
+          sceneConfig.directionalLight ? { type: PCFSoftShadowMap } : undefined
+        }
       >
         <Suspense>
           <EggController keyMapping={keyMapping} />
-          <DynamicScene adminEnabled={adminEnabled} />
+          <DynamicScene
+            key={configVersion}
+            adminEnabled={adminEnabled}
+            onReady={() => setSceneReady(true)}
+          />
         </Suspense>
       </Canvas>
+      <LoadingSkeleton hidden={sceneReady} />
+      {adminEnabled && (
+        <SceneConfigPanel onChange={() => setConfigVersion((v) => v + 1)} />
+      )}
     </div>
   );
 }

--- a/src/styles/LoadingSkeleton.module.css
+++ b/src/styles/LoadingSkeleton.module.css
@@ -1,0 +1,58 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10;
+  overflow: hidden;
+  /* Echoes the scene's dark gradient sky (#070b1a teal/mauve over #0a0610). */
+  background:
+    radial-gradient(
+      ellipse at 30% 20%,
+      rgba(0, 123, 167, 0.12),
+      transparent 60%
+    ),
+    radial-gradient(
+      ellipse at 75% 80%,
+      rgba(111, 69, 110, 0.14),
+      transparent 60%
+    ),
+    #0a0610;
+  opacity: 1;
+  transition: opacity 600ms ease-out;
+  pointer-events: auto;
+}
+
+.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.star {
+  position: absolute;
+  border-radius: 50%;
+  background: var(--star-color, #cfe8ff);
+  /* Soft glow to mirror the bloomed stars in the real scene. */
+  box-shadow: 0 0 6px var(--star-color, #cfe8ff);
+  opacity: 0;
+  animation: twinkle var(--twinkle-duration, 2.4s) ease-in-out infinite;
+  animation-delay: var(--twinkle-delay, 0s);
+  will-change: opacity, transform;
+}
+
+@keyframes twinkle {
+  0%,
+  100% {
+    opacity: 0.15;
+    transform: scale(0.7);
+  }
+  50% {
+    opacity: 0.9;
+    transform: scale(1.1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .star {
+    animation: none;
+    opacity: 0.5;
+  }
+}

--- a/src/styles/SceneConfigPanel.module.css
+++ b/src/styles/SceneConfigPanel.module.css
@@ -1,0 +1,133 @@
+.root {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 12px;
+  font-family: var(--font-mono);
+}
+
+.toggle {
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(76, 193, 255, 0.4);
+  border-radius: 10px;
+  background: rgba(10, 6, 16, 0.7);
+  backdrop-filter: blur(6px);
+  cursor: pointer;
+  transition:
+    border-color 150ms ease,
+    background 150ms ease;
+}
+
+.toggle:hover {
+  border-color: #4cc1ff;
+  background: rgba(10, 6, 16, 0.9);
+}
+
+.bars {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.bars span {
+  display: block;
+  width: 22px;
+  height: 2px;
+  background: #4cc1ff;
+  border-radius: 2px;
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 14px;
+  min-width: 200px;
+  border: 1px solid rgba(76, 193, 255, 0.4);
+  border-radius: 10px;
+  background: rgba(10, 6, 16, 0.85);
+  backdrop-filter: blur(6px);
+}
+
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.group + .group {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(76, 193, 255, 0.15);
+}
+
+.groupTitle {
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(76, 193, 255, 0.7);
+  padding: 0 4px 2px;
+}
+
+.option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 4px;
+  font-size: 13px;
+  color: #cfe8ff;
+  cursor: pointer;
+  user-select: none;
+}
+
+.option:hover {
+  color: #ffffff;
+}
+
+.option input {
+  width: 15px;
+  height: 15px;
+  accent-color: #4cc1ff;
+  cursor: pointer;
+}
+
+/* Sub-options indented under their parent. */
+.child {
+  padding-left: 18px;
+}
+
+/* Disabled because the parent option is off. */
+.disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.disabled input {
+  cursor: not-allowed;
+}
+
+/* A label + dropdown row (e.g. particle color style). */
+.select {
+  justify-content: space-between;
+  cursor: default;
+}
+
+.select select {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-transform: capitalize;
+  color: #cfe8ff;
+  background: rgba(10, 6, 16, 0.9);
+  border: 1px solid rgba(76, 193, 255, 0.4);
+  border-radius: 6px;
+  padding: 3px 6px;
+  cursor: pointer;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2020",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
Swap to WebGPU (WebGL2 fallback) and reimplement all GLSL shaders in TSL node materials: gradient sky, twinkle stars, emissive stars, shooting-star trails. Emissive-only bloom via MRT, output dithering to break banding.

Add fly camera controls (WASD/arrows, velocity/accel/friction, bounded to the tornado, auto-return on idle), a hamburger admin SceneConfig panel, particle color-lerp styles (solid/band/stripe, randomized per load), and an animated loading skeleton.

Shooting stars get elliptical trails that shorten on fade and vary in depth. Unify cursor ownership in the link column (hidden when text fades, pointer on hover). Allocation-free hot paths (reused scratch vectors, fixed-per-spawn trail scatter), gated per-frame setState, and a shared sphere-direction sampler.